### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Next, replace the version in the plugin line (only change the GradleRIO line):
 ```gradle
 plugins {
     // ... other plugins ...
-    id "jaci.openrio.gradle.GradleRIO" version "2018.06.21"
+    id "edu.wpi.first.GradleRIO" version "2018.06.21"
 }
 ```
 


### PR DESCRIPTION
From looking at https://plugins.gradle.org, jaci.openrio.gradle.GradleRIO is frozen at 2018.03.06, while edu.wpi.first.GradleRIO has the new version. Fixing README to make experimentation during the offseason less confusing