### PR TITLE
Add output stripping to binaries built with rio compiler

### DIFF
--- a/src/main/groovy/jaci/openrio/gradle/wpi/toolchain/WPIRoboRioGcc.groovy
+++ b/src/main/groovy/jaci/openrio/gradle/wpi/toolchain/WPIRoboRioGcc.groovy
@@ -38,7 +38,7 @@ class WPIRoboRioGcc extends AbstractGccCompatibleToolChain {
         eachPlatform(new Action<GccPlatformToolChain>() {
             @Override
             void execute(GccPlatformToolChain target) {
-                String gccPrefix = "arm-frc-linux-gnueabi-"
+                String gccPrefix = getPrefix()
                 String gccSuffix = OperatingSystem.current().isWindows() ? ".exe" : ""
 
                 target.cCompiler.executable =           gccPrefix + "gcc" + gccSuffix
@@ -87,5 +87,9 @@ class WPIRoboRioGcc extends AbstractGccCompatibleToolChain {
     @Override
     public String getTypeName() {
         return "RoboRioGcc"
+    }
+
+    public String getPrefix() {
+        return "arm-frc-linux-gnueabi-"
     }
 }


### PR DESCRIPTION
Currently will always happen, should add a way to disable at some point. But in theory, it is a change that is always safe to do.