### PR TITLE
Add output stripping to binaries built with rio compiler

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/toolchain/WPIToolchainExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/toolchain/WPIToolchainExtension.groovy
@@ -1,0 +1,8 @@
+package edu.wpi.first.gradlerio.wpi.toolchain
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class WPIToolchainExtension {
+    boolean skipStrip = false
+}


### PR DESCRIPTION
Currently will always happen, should add a way to disable at some point. But in theory, it is a change that is always safe to do.