### PR TITLE
Add parsing the wpilib json file for team number

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCPlugin.groovy
@@ -62,7 +62,20 @@ class FRCPlugin implements Plugin<Project> {
         project.extensions.add("getTeamOrDefault", { Integer teamDefault ->
             if (project.hasProperty("teamNumber"))
                 return Integer.parseInt(project.property("teamNumber") as String)
-            return teamDefault
+
+            def number = getTeamNumberFromJSON()
+            if (number < 0)
+                return teamDefault
+            return number
+        } as Closure<Integer>);
+
+        project.extensions.add("getTeamNumber", {
+            if (project.hasProperty("teamNumber"))
+                return Integer.parseInt(project.property("teamNumber") as String)
+            def number = getTeamNumberFromJSON()
+            if (number < 0)
+                throw new TeamNumberNotFoundException()
+            return number
         } as Closure<Integer>);
 
         project.extensions.add("getDebugOrDefault", { Boolean debugDefault ->
@@ -170,6 +183,17 @@ class FRCPlugin implements Plugin<Project> {
                 }
             }
         }
+    }
+
+    private int getTeamNumberFromJSON() {
+        def jsonFile = project.rootProject.file(".wpilib/wpilib_preferences.json")
+        if (jsonFile.exists()) {
+            def parsedJson = new groovy.json.JsonSlurper().parseText(jsonFile.text)
+            def teamNumber = parsedJson['teamNumber']
+            if (teamNumber != null)
+                return teamNumber as Integer
+        }
+        return -1;
     }
 
     static class FRCRules extends RuleSource {

--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/TeamNumberNotFoundException.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/TeamNumberNotFoundException.groovy
@@ -1,0 +1,11 @@
+package edu.wpi.first.gradlerio.frc
+
+import groovy.transform.CompileStatic
+import org.gradle.api.GradleException
+
+@CompileStatic
+class TeamNumberNotFoundException extends GradleException {
+    public TeamNumberNotFoundException() {
+      super("Could not find team number. Make sure either one is passed in, or the team number is set in the wpilib_preferences.json file. You can also use getTeamOrDefault(number) to pass in a default team number instead of getTeamValue")
+    }
+}


### PR DESCRIPTION
Closes #124

Parses the file after the command line arguments. Also adds a getTeamValue call that takes no parameter, and throws if if can't find a team number
That way we don't need a team number at all in the gradle file