### PR TITLE
Add installation script for devices running ChromeOS

### DIFF
--- a/chromeos_install_gradle.sh
+++ b/chromeos_install_gradle.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+command -v crew >/dev/null 2>&1 || { bash $(curl https://github.com/skycocker/chromebrew/raw/master/install.sh); crew install git wget}
+
+crew install jdk8
+crew install gradle
+
+sudo mount -o remount,exec /
+sudo mount -o remount,exec ~/
+
+echo "sudo mount -o remount,exec / && sudo mount -o remount,exec ~/" >> ~/.profile
+
+echo "\033[1;34mUse gradle instead of ./gradlew when working with any GradleRIO projects\033[0m"


### PR DESCRIPTION
I am currently working on getting all wpilib tools to work on ChromeOS in developer mode. 

This install script handles package management, installation, and deals with chromeos' file execution problems.