### PR TITLE
Add GradleRIO dependency for Gradle VS Code extension

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compile 'gradle.plugin.jaci.gradle:DeployTools:2018.08.27a'
     compile 'de.undercouch:gradle-download-task:3.1.2'
     compile 'com.google.code.gson:gson:2.2.4'
+    compile 'gradle.plugin.edu.wpi.first:gradle-cpp-vscode:0.4.2'
 }
 
 buildScan {

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIPlugin.groovy
@@ -4,6 +4,7 @@ import edu.wpi.first.gradlerio.wpi.dependencies.WPIJavaDeps
 import edu.wpi.first.gradlerio.wpi.dependencies.WPINativeDeps
 import edu.wpi.first.gradlerio.wpi.dependencies.tools.WPIToolsPlugin
 import edu.wpi.first.gradlerio.wpi.toolchain.WPIToolchainPlugin
+import edu.wpi.first.vscode.GradleVsCode
 import groovy.transform.CompileStatic
 import jaci.gradle.log.ETLogger
 import jaci.gradle.log.ETLoggerFactory
@@ -28,6 +29,7 @@ class WPIPlugin implements Plugin<Project> {
             logger.info("DeployTools Native Project Detected".toString())
             project.pluginManager.apply(WPINativeDeps)
             project.pluginManager.apply(WPIToolchainPlugin)
+            project.pluginManager.apply(GradleVsCode)
         }
 
         project.tasks.register("wpi") { Task task ->


### PR DESCRIPTION
This way we don't need to modify multiple imports during updates. It only gets applied if there is a native project