### PR TITLE
Add base tests to make sure Java and C++ projects init correctly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,11 @@ dependencies {
     compile 'de.undercouch:gradle-download-task:3.1.2'
     compile 'com.google.code.gson:gson:2.2.4'
     compile 'gradle.plugin.edu.wpi.first:gradle-cpp-vscode:0.4.2'
+
+    testCompile('org.spockframework:spock-core:1.1-groovy-2.4') {
+        exclude group: 'org.codehaus.groovy'
+    }
+    testCompile gradleTestKit()
 }
 
 buildScan {

--- a/src/test/groovy/edu/wpi/first/gradlerio/GradleRioInitializationTest.groovy
+++ b/src/test/groovy/edu/wpi/first/gradlerio/GradleRioInitializationTest.groovy
@@ -1,0 +1,54 @@
+package edu.wpi.first.gradlerio
+
+import org.gradle.testkit.runner.GradleRunner
+import static org.gradle.testkit.runner.TaskOutcome.*
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class GradleRioInitializationTest extends Specification {
+    @Rule final TemporaryFolder testProjectDir = new TemporaryFolder()
+    File buildFile
+
+    def setup() {
+        buildFile = testProjectDir.newFile('build.gradle')
+    }
+
+    def "Cpp Project Initializes Correctly"() {
+        given:
+        buildFile << """
+plugins {
+    id 'cpp'
+    id 'edu.wpi.first.GradleRIO'
+}
+"""
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments('tasks')
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(':tasks').outcome == SUCCESS
+    }
+
+    def "Java Project Initializes Correctly"() {
+        given:
+        buildFile << """
+plugins {
+    id 'java'
+    id 'edu.wpi.first.GradleRIO'
+}
+"""
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(testProjectDir.root)
+            .withArguments('tasks')
+            .withPluginClasspath()
+            .build()
+
+        then:
+        result.task(':tasks').outcome == SUCCESS
+    }
+}


### PR DESCRIPTION
With just the Java or C++ plugin and nothing else, configuration should be successfull

Regrestion tested, and this would have caught #161 