### PR TITLE
Add way to enable the wpilib development in releases that get put in ~/releases/maven

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.groovy
@@ -12,6 +12,8 @@ class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo> {
 
     boolean useDevelopment
     boolean useLocal
+    boolean useFrcMavenLocalDevelopment
+    boolean useFrcMavenLocalRelease
 
     WPIMavenExtension(Project project) {
         super(WPIMavenRepo.class, DirectInstantiator.INSTANCE)
@@ -19,6 +21,8 @@ class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo> {
 
         this.useDevelopment = true
         this.useLocal = true
+        this.useFrcMavenLocalDevelopment = false
+        this.useFrcMavenLocalRelease = false
 
         mirror("Official") { WPIMavenRepo mirror ->
             mirror.release = "http://first.wpi.edu/FRC/roborio/maven/release"

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPICommonDeps.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPICommonDeps.groovy
@@ -22,6 +22,20 @@ class WPICommonDeps implements Plugin<Project> {
                 }
             }
 
+            if (wpi.maven.useFrcMavenLocalDevelopment) {
+                project.repositories.maven { MavenArtifactRepository repo ->
+                    repo.name = "FRCDevelopmentLocal"
+                    repo.url = "${System.getProperty('user.home')}/releases/maven/development"
+                }
+            }
+
+            if (wpi.maven.useFrcMavenLocalRelease) {
+                project.repositories.maven { MavenArtifactRepository repo ->
+                    repo.name = "FRCReleaseLocal"
+                    repo.url = "${System.getProperty('user.home')}/releases/maven/release"
+                }
+            }
+
             def sortedMirrors = wpi.maven.sort { it.priority }
 
             // If enabled, the development branch should have a higher weight than the release


### PR DESCRIPTION
These are useful when trying to do local development. Theyre verbose because we don't normally want them enabled.