### PR TITLE
Use ObjectFactory to create extendable objects for DSL

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
@@ -2,8 +2,9 @@ package edu.wpi.first.gradlerio.wpi
 
 import groovy.transform.CompileStatic
 import org.gradle.api.Project
-import org.gradle.api.plugins.ExtensionAware
 import org.gradle.internal.os.OperatingSystem
+
+import javax.inject.Inject
 
 @CompileStatic
 class WPIExtension {
@@ -39,9 +40,12 @@ class WPIExtension {
     final String nativeClassifier
     final String toolsClassifier
 
+    @Inject
     WPIExtension(Project project) {
         this.project = project
-        maven = ((ExtensionAware)this).extensions.create('maven', WPIMavenExtension, project)
+        def factory = project.objects
+
+        maven = factory.newInstance(WPIMavenExtension, project)
 
         if (project.hasProperty('forceNativeClassifier')) {
             this.nativeClassifier = project.findProperty('forceNativeClassifier')

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.groovy
@@ -5,6 +5,8 @@ import org.gradle.api.Project
 import org.gradle.api.internal.DefaultNamedDomainObjectSet
 import org.gradle.internal.reflect.DirectInstantiator
 
+import javax.inject.Inject
+
 @CompileStatic
 class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo> {
 
@@ -15,6 +17,7 @@ class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo> {
     boolean useFrcMavenLocalDevelopment
     boolean useFrcMavenLocalRelease
 
+    @Inject
     WPIMavenExtension(Project project) {
         super(WPIMavenRepo.class, DirectInstantiator.INSTANCE)
         this.project = project

--- a/src/test/groovy/edu/wpi/first/gradlerio/wpi/WPIExtensionExtendableTest.groovy
+++ b/src/test/groovy/edu/wpi/first/gradlerio/wpi/WPIExtensionExtendableTest.groovy
@@ -1,0 +1,47 @@
+package edu.wpi.first.gradlerio.wpi
+
+import groovy.transform.CompileStatic
+import edu.wpi.first.gradlerio.wpi.WPIPlugin
+import edu.wpi.first.gradlerio.wpi.WPIExtension
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.Project
+
+class WPIExtensionExtendableTest extends Specification {
+
+    def outerName = ''
+
+    def "can extend wpi extension"() {
+        outerName = ''
+        Project project = ProjectBuilder.builder().build()
+        project.pluginManager.apply(WPIPlugin)
+        def wpi = (WPIExtension)project.extensions.getByType(WPIExtension)
+        wpi.extensions.add('testAdd', { String name ->
+            outerName = name
+        })
+
+        when:
+            def test = wpi.extensions.getByName('testAdd')
+            test('hello')
+        then:
+            outerName == 'hello'
+    }
+
+    @CompileStatic
+    def "can extend wpi extension static"() {
+        outerName = ''
+        Project project = ProjectBuilder.builder().build()
+        project.pluginManager.apply(WPIPlugin)
+        def wpi = project.extensions.getByType(WPIExtension) as ExtensionAware
+        wpi.extensions.add('testAdd', { String name ->
+            outerName = name
+        })
+
+        when:
+            def test = wpi.extensions.getByName('testAdd') as Closure
+            test('hello')
+        then:
+            outerName == 'hello'
+    }
+}

--- a/src/test/groovy/edu/wpi/first/gradlerio/wpi/WPIMavenExtensionExtendableTest.groovy
+++ b/src/test/groovy/edu/wpi/first/gradlerio/wpi/WPIMavenExtensionExtendableTest.groovy
@@ -1,0 +1,49 @@
+package edu.wpi.first.gradlerio.wpi
+
+import groovy.transform.CompileStatic
+import edu.wpi.first.gradlerio.wpi.WPIPlugin
+import edu.wpi.first.gradlerio.wpi.WPIExtension
+import edu.wpi.first.gradlerio.wpi.WPIMavenExtension
+import org.gradle.testfixtures.ProjectBuilder
+import spock.lang.Specification
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.api.Project
+
+class WPIMavenExtensionExtendableTest extends Specification {
+
+    def outerName = ''
+
+    def "can extend wpi maven extension"() {
+        outerName = ''
+        Project project = ProjectBuilder.builder().build()
+        project.pluginManager.apply(WPIPlugin)
+        def wpi = (WPIExtension)project.extensions.getByType(WPIExtension)
+        wpi.maven.extensions.add('testAdd', { String name ->
+            outerName = name
+        })
+
+        when:
+            def test = wpi.maven.extensions.getByName('testAdd')
+            test('hello')
+        then:
+            outerName == 'hello'
+    }
+
+    @CompileStatic
+    def "can extend wpi  maven extension static"() {
+        outerName = ''
+        Project project = ProjectBuilder.builder().build()
+        project.pluginManager.apply(WPIPlugin)
+        def wpi = project.extensions.getByType(WPIExtension)
+        def wpiMaven = wpi.maven as ExtensionAware
+        wpiMaven.extensions.add('testAdd', { String name ->
+            outerName = name
+        })
+
+        when:
+            def test = wpiMaven.extensions.getByName('testAdd') as Closure
+            test('hello')
+        then:
+            outerName == 'hello'
+    }
+}


### PR DESCRIPTION
Cleaner then casting ExtensionAware, and safer too, as it doesn't create a named extension

Also adds tests to ensure the things are always extendable