### PR TITLE
Bump to working 2019 versions of all dependencies

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
@@ -8,9 +8,9 @@ import org.gradle.internal.os.OperatingSystem
 @CompileStatic
 class WPIExtension {
     // WPILib (first.wpi.edu/FRC/roborio/maven) libs
-    String wpilibVersion = "2018.4.1-20180921151738-1194-gf89274f"
-    String niLibrariesVersion = "2018.17.1"
-    String opencvVersion = "3.2.0"
+    String wpilibVersion = "2018.4.1-20181003000242-1213-gfd82153"
+    String niLibrariesVersion = "2019.4.1"
+    String opencvVersion = "3.4.3"
 
     String wpilibYear = '2019'
 
@@ -19,11 +19,11 @@ class WPIExtension {
     String jreArtifactLocation = "edu.wpi.first.jdk:roborio-2019:11.0.0u28-1"
 
     // WPILib (first.wpi.edu/FRC/roborio/maven) Utilities
-    String smartDashboardVersion = "3.0.0"
-    String shuffleboardVersion = "1.424242.3.1-20181007163852-59-gc57db86"
-    String outlineViewerVersion = "2.424242.0.4-20181007161343-8-g71b005c"
-    String robotBuilderVersion = "3.0.1"
-    String pathWeaverVersion = "v0.0.0"
+    String smartDashboardVersion = "3.0.1-3-ga271736"
+    String shuffleboardVersion = "1.3.1-61-gac4305a"
+    String outlineViewerVersion = "2.0.4-2-g0161ee6"
+    String robotBuilderVersion = "3.0.1-5-g61cc7b4"
+    String pathWeaverVersion = "2019.0.0-alpha-0"
 
     // WPILib Toolchain (https://github.com/wpilibsuite/toolchain-builder/releases/latest) version and tag
     String toolchainTag = 'v2019-2'

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
@@ -8,7 +8,7 @@ import org.gradle.internal.os.OperatingSystem
 @CompileStatic
 class WPIExtension {
     // WPILib (first.wpi.edu/FRC/roborio/maven) libs
-    String wpilibVersion = "2018.4.1-20181003000242-1213-gfd82153"
+    String wpilibVersion = "2018.4.1-1230-g7068551"
     String niLibrariesVersion = "2019.4.1"
     String opencvVersion = "3.4.3"
 

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
@@ -10,7 +10,7 @@ class WPIExtension {
     // WPILib (first.wpi.edu/FRC/roborio/maven) libs
     String wpilibVersion = "2018.4.1-1230-g7068551"
     String niLibrariesVersion = "2019.4.1"
-    String opencvVersion = "3.4.3"
+    String opencvVersion = "3.4.3-7"
 
     String wpilibYear = '2019'
 

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIJavaDeps.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIJavaDeps.groovy
@@ -23,7 +23,7 @@ class WPIJavaDeps implements Plugin<Project> {
         def nativeclassifier = wpi.nativeClassifier
 
         project.dependencies.ext.wpilibDesktopJni = {
-             ["org.opencv:opencv-cpp:${wpi.opencvVersion}:${nativeclassifier}@zip",
+             ["edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:${nativeclassifier}@zip",
              "edu.wpi.first.hal:hal-cpp:${wpi.wpilibVersion}:${nativeclassifier}@zip",
              "edu.wpi.first.wpiutil:wpiutil-cpp:${wpi.wpilibVersion}:${nativeclassifier}@zip",
              "edu.wpi.first.ntcore:ntcore-cpp:${wpi.wpilibVersion}:${nativeclassifier}@zip",
@@ -33,7 +33,7 @@ class WPIJavaDeps implements Plugin<Project> {
         project.dependencies.ext.wpilibJni = {
             // Note: we use -cpp artifacts instead of -jni artifacts as the -cpp ones are linked with shared
             // libraries, while the -jni ones are standalone (have static libs embedded).
-            ["org.opencv:opencv-cpp:${wpi.opencvVersion}:linuxathena@zip",
+            ["edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:linuxathena@zip",
              "edu.wpi.first.hal:hal-cpp:${wpi.wpilibVersion}:linuxathena@zip",
              "edu.wpi.first.wpiutil:wpiutil-cpp:${wpi.wpilibVersion}:linuxathena@zip",
              "edu.wpi.first.ntcore:ntcore-cpp:${wpi.wpilibVersion}:linuxathena@zip",
@@ -50,7 +50,7 @@ class WPIJavaDeps implements Plugin<Project> {
             ["edu.wpi.first.wpilibj:wpilibj-java:${wpi.wpilibVersion}",
              "edu.wpi.first.ntcore:ntcore-java:${wpi.wpilibVersion}",
              "edu.wpi.first.wpiutil:wpiutil-java:${wpi.wpilibVersion}",
-             "org.opencv:opencv-java:${wpi.opencvVersion}",
+             "edu.wpi.first.thirdparty.frc2019.opencv:opencv-java:${wpi.opencvVersion}",
              "edu.wpi.first.cscore:cscore-java:${wpi.wpilibVersion}",
              "edu.wpi.first.cameraserver:cameraserver-java:${wpi.wpilibVersion}",
              "edu.wpi.first.hal:hal-java:${wpi.wpilibVersion}"]
@@ -60,7 +60,7 @@ class WPIJavaDeps implements Plugin<Project> {
             ["edu.wpi.first.wpilibj:wpilibj-java:${wpi.wpilibVersion}:sources",
              "edu.wpi.first.ntcore:ntcore-java:${wpi.wpilibVersion}:sources",
              "edu.wpi.first.wpiutil:wpiutil-java:${wpi.wpilibVersion}:sources",
-             "org.opencv:opencv-java:${wpi.opencvVersion}:sources",
+             "edu.wpi.first.thirdparty.frc2019.opencv:opencv-java:${wpi.opencvVersion}:sources",
              "edu.wpi.first.cscore:cscore-java:${wpi.wpilibVersion}:sources",
              "edu.wpi.first.cameraserver:cameraserver-java:${wpi.wpilibVersion}:sources",
              "edu.wpi.first.hal:hal-java:${wpi.wpilibVersion}:sources"]

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPINativeDeps.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPINativeDeps.groovy
@@ -164,7 +164,7 @@ class WPINativeDeps implements Plugin<Project> {
                 common(lib)
                 lib.targetPlatforms << 'desktop'
                 lib.headerDirs << ''
-                lib.maven = "org.opencv:opencv-cpp:${wpi.opencvVersion}:headers@zip"
+                lib.maven = "edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:headers@zip"
                 lib.configuration = 'native_opencv'
                 null
             }
@@ -174,7 +174,7 @@ class WPINativeDeps implements Plugin<Project> {
                 lib.libraryName = 'opencv_binaries'
                 lib.dynamicMatchers = ['**/libopencv*.so.*', '**/libopencv*.so']
                 lib.sharedMatchers = ['**/libopencv*.so.*', '**/libopencv*.so']
-                lib.maven = "org.opencv:opencv-cpp:${wpi.opencvVersion}:linuxathena@zip"
+                lib.maven = "edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:linuxathena@zip"
                 lib.configuration = 'native_opencv'
                 null
             }
@@ -185,9 +185,11 @@ class WPINativeDeps implements Plugin<Project> {
                     lib.libraryName = 'opencv_binaries'
                     lib.targetPlatforms = ['desktop']
                     lib.staticMatchers = ['**/*opencv*.lib']
-                    lib.sharedMatchers = ['**/*opencv*.so', '**/*opencv*.so.*', '**/*opencv*.dylib']
+                    // The mac matcher is weird because we want to match libopencv_core.3.4.dylib
+                    // but not libopencv_java343.dylib. The java library cannot be linked as of 2019 libs.
+                    lib.sharedMatchers = ['**/*opencv*.so', '**/*opencv*.so.*', '**/*opencv*.*.dylib']
                     lib.dynamicMatchers = lib.sharedMatchers + '**/*opencv*.dll'
-                    lib.maven = "org.opencv:opencv-cpp:${wpi.opencvVersion}:${nativeclassifier}@zip"
+                    lib.maven = "edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:${nativeclassifier}@zip"
                     lib.configuration = 'native_opencv_desktop'
                     null
                 }

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/toolchain/WPIRoboRioGcc.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/toolchain/WPIRoboRioGcc.groovy
@@ -82,25 +82,6 @@ class WPIRoboRioGcc extends AbstractGccCompatibleToolChain {
                     target.linker.executable =              toolchainDiscoverer.composeTool("g++", frcYear)
                     target.assembler.executable =           toolchainDiscoverer.composeTool("as", frcYear)
                     target.staticLibArchiver.executable =   toolchainDiscoverer.composeTool("ar", frcYear)
-
-                    if (customPath) {
-                        // Sysroot is usually /frc, but since we're overriding the default install directory,
-                        // we can modify the sysroot in order to support the location. This is the base for system libs
-                        // and such.
-                        def sysroot = toolchainDiscoverer.sysroot().get().absolutePath
-
-                        target.cCompiler.withArguments ({ List<String> a ->
-                            a << '--sysroot' << sysroot
-                        } as Action<? super List<String>>)
-
-                        target.cppCompiler.withArguments ({ List<String> a ->
-                            a << '--sysroot' << sysroot
-                        } as Action<? super List<String>>)
-
-                        target.linker.withArguments ({ List<String> a ->
-                            a << '--sysroot' << sysroot
-                        } as Action<? super List<String>>)
-                    }
                 }
             })
 

--- a/versionupdates.gradle
+++ b/versionupdates.gradle
@@ -2,10 +2,13 @@
 def versionMap = [
   wpilibVersion: 'edu.wpi.first.wpilibj:wpilibj-java:+',
   smartDashboardVersion: 'edu.wpi.first.wpilib:SmartDashboard:+',
-  outlineViewerVersion: 'edu.wpi.first.wpilib:OutlineViewer:+',
+  outlineViewerVersion: 'edu.wpi.first.wpilib:OutlineViewer:+:win64',
   robotBuilderVersion: 'edu.wpi.first.wpilib:RobotBuilder:+',
-  shuffleboardVersion: 'edu.wpi.first.shuffleboard:app:+',
-  opencvVersion: 'org.opencv:opencv-java:+'
+  shuffleboardVersion: 'edu.wpi.first.shuffleboard:shuffleboard:+:win64',
+  pathWeaverVersion: 'edu.wpi.first.wpilib:PathWeaver:+:win64',
+  opencvVersion: 'edu.wpi.first.thirdparty.frc2019.opencv:opencv-java:+',
+  googleTestVersion: 'edu.wpi.first.thirdparty.frc2019:googletest:+:headers',
+  niLibrariesVersion: 'edu.wpi.first.ni-libraries:chipobject:+:headers'
 ]
 
 configurations {
@@ -14,7 +17,7 @@ configurations {
 
 project.repositories.maven { repo ->
     repo.name = "WPI"
-    repo.url = "http://first.wpi.edu/FRC/roborio/maven/release"
+    repo.url = "http://first.wpi.edu/FRC/roborio/maven/development"
 }
 
 dependencies {
@@ -33,7 +36,7 @@ tasks.register('UpdateVersions') {
     configurations.gradleRioVersions.resolvedConfiguration.resolvedArtifacts.each {
       versionMap.each { key, value ->
         def id = it.moduleVersion.id
-        if (value == "${id.group}:${it.name}:+".toString()) {
+        if (value.startsWith("${id.group}:${it.name}:+".toString())) {
           def localRegex = regex.replace('placeholder', key)
           extText = extText.replaceAll(localRegex, "String ${key} = \"${id.version}\"".toString())
         }


### PR DESCRIPTION


For now, don't run the update versions task, + is currently broken because of an upstream change