### PR TITLE
Fix java debugging and change port

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCJavaArtifact.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCJavaArtifact.groovy
@@ -30,8 +30,8 @@ class FRCJavaArtifact extends JavaArtifact {
     List<String> jvmArgs = []
     List<String> arguments = []
     boolean debug = false
-    int debugPort = 8348
-    String debugFlags = "-XX:+UsePerfData -agentlib:jdwp=transport=dt_socket,address=${debugPort},server=y,suspend=y"
+    int debugPort = 8349
+    String debugFlags = "-XX:+UsePerfData -agentlib:jdwp=transport=dt_socket,address=0.0.0.0:${debugPort},server=y,suspend=y"
 
     def robotCommand = {
         "/usr/local/frc/JRE/bin/java -Djava.library.path=/usr/local/frc/lib/ ${jvmArgs.join(" ")} ${debug ? debugFlags : ""} -jar \"<<BINARY>>\" ${arguments.join(" ")}"


### PR DESCRIPTION
Debugging needs to be addressed to 0.0.0.0 in order to allow remote connections

Debugging port shouldn't match between C++ and Java in order to allow dual mode debugging in the future

Closes #211