### PR TITLE
Adds changes needed for separate debug and release dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ repositories {
 }
 
 dependencies {
-//    compile 'jaci.gradle:EmbeddedTools:2018.10.16a'
-    compile 'gradle.plugin.jaci.gradle:EmbeddedTools:2018.10.16a'
+    compile 'jaci.gradle:EmbeddedTools:2018.10.30'
+//    compile 'gradle.plugin.jaci.gradle:EmbeddedTools:2018.10.16a'
     compile 'de.undercouch:gradle-download-task:3.1.2'
     compile 'com.google.code.gson:gson:2.2.4'
     compile 'gradle.plugin.edu.wpi.first:gradle-cpp-vscode:0.5.0'
@@ -41,7 +41,7 @@ buildScanRecipes {
 
 group = "edu.wpi.first"
 archivesBaseName = "GradleRIO"
-version = "2019.1.1-beta-1"
+version = "2019.1.1-beta-2-pre-1"
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -16,8 +16,8 @@ repositories {
 }
 
 dependencies {
-    compile 'jaci.gradle:EmbeddedTools:2018.10.30'
-//    compile 'gradle.plugin.jaci.gradle:EmbeddedTools:2018.10.16a'
+    // compile 'jaci.gradle:EmbeddedTools:2018.10.30'
+    compile 'gradle.plugin.jaci.gradle:EmbeddedTools:2018.10.30'
     compile 'de.undercouch:gradle-download-task:3.1.2'
     compile 'com.google.code.gson:gson:2.2.4'
     compile 'gradle.plugin.edu.wpi.first:gradle-cpp-vscode:0.5.0'

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
@@ -10,13 +10,13 @@ import javax.inject.Inject
 @CompileStatic
 class WPIExtension {
     // WPILib (first.wpi.edu/FRC/roborio/maven) libs
-    String wpilibVersion = "2019.1.1-beta-1"
+    String wpilibVersion = "2019.1.1-beta-1-16-g1dec039"
     String niLibrariesVersion = "2019.4.1"
-    String opencvVersion = "3.4.3-7"
+    String opencvVersion = "3.4.3-15"
 
     String wpilibYear = '2019'
 
-    String googleTestVersion = "1.8.0-1-4e4df22"
+    String googleTestVersion = "1.8.0-4-4e4df22"
 
     String jreArtifactLocation = "edu.wpi.first.jdk:roborio-2019:11.0.0u28-1"
 

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.groovy
@@ -22,7 +22,7 @@ class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo> {
         super(WPIMavenRepo.class, DirectInstantiator.INSTANCE)
         this.project = project
 
-        this.useDevelopment = false
+        this.useDevelopment = true
         this.useLocal = true
         this.useFrcMavenLocalDevelopment = false
         this.useFrcMavenLocalRelease = false

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIJavaDeps.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIJavaDeps.groovy
@@ -23,21 +23,21 @@ class WPIJavaDeps implements Plugin<Project> {
         def nativeclassifier = wpi.nativeClassifier
 
         project.dependencies.ext.wpilibDesktopJni = {
-             ["edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:${nativeclassifier}@zip",
-             "edu.wpi.first.hal:hal-cpp:${wpi.wpilibVersion}:${nativeclassifier}@zip",
-             "edu.wpi.first.wpiutil:wpiutil-cpp:${wpi.wpilibVersion}:${nativeclassifier}@zip",
-             "edu.wpi.first.ntcore:ntcore-cpp:${wpi.wpilibVersion}:${nativeclassifier}@zip",
-             "edu.wpi.first.cscore:cscore-cpp:${wpi.wpilibVersion}:${nativeclassifier}@zip"]
+             ["edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:${nativeclassifier}debug@zip",
+             "edu.wpi.first.hal:hal-cpp:${wpi.wpilibVersion}:${nativeclassifier}debug@zip",
+             "edu.wpi.first.wpiutil:wpiutil-cpp:${wpi.wpilibVersion}:${nativeclassifier}debug@zip",
+             "edu.wpi.first.ntcore:ntcore-cpp:${wpi.wpilibVersion}:${nativeclassifier}debug@zip",
+             "edu.wpi.first.cscore:cscore-cpp:${wpi.wpilibVersion}:${nativeclassifier}debug@zip"]
         }
 
         project.dependencies.ext.wpilibJni = {
             // Note: we use -cpp artifacts instead of -jni artifacts as the -cpp ones are linked with shared
             // libraries, while the -jni ones are standalone (have static libs embedded).
-            ["edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:linuxathena@zip",
-             "edu.wpi.first.hal:hal-cpp:${wpi.wpilibVersion}:linuxathena@zip",
-             "edu.wpi.first.wpiutil:wpiutil-cpp:${wpi.wpilibVersion}:linuxathena@zip",
-             "edu.wpi.first.ntcore:ntcore-cpp:${wpi.wpilibVersion}:linuxathena@zip",
-             "edu.wpi.first.cscore:cscore-cpp:${wpi.wpilibVersion}:linuxathena@zip"]
+            ["edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:linuxathenadebug@zip",
+             "edu.wpi.first.hal:hal-cpp:${wpi.wpilibVersion}:linuxathenadebug@zip",
+             "edu.wpi.first.wpiutil:wpiutil-cpp:${wpi.wpilibVersion}:linuxathenadebug@zip",
+             "edu.wpi.first.ntcore:ntcore-cpp:${wpi.wpilibVersion}:linuxathenadebug@zip",
+             "edu.wpi.first.cscore:cscore-cpp:${wpi.wpilibVersion}:linuxathenadebug@zip"]
         }
 
         project.dependencies.ext.wpilib = {

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/toolchain/WPIToolchainPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/toolchain/WPIToolchainPlugin.groovy
@@ -292,13 +292,15 @@ class WPIToolchainPlugin implements Plugin<Project> {
 
                     // Both release and debug should enable the the debugging options
                     // and MT crt mode. Debugging here is always safe
-                    bin.cppCompiler.args << '/Zi' << '/Zc:inline' << '/MT'
+                    bin.cppCompiler.args << '/Zi' << '/Zc:inline'
                     bin.linker.args << '/DEBUG:FULL'
 
                     // Build release in optimized mode.
                     if (bin.buildType.name.equals('release')) {
-                        bin.cppCompiler.args << '/O2'
+                        bin.cppCompiler.args << '/O2' << '/MD'
                         bin.linker.args << '/OPT:REF' << '/OPT:ICF'
+                    } else {
+                        bin.cppCompiler.args << '/MDd'
                     }
                 } else {
                     bin.cppCompiler.args << '-std=c++14' << '-g' << '-rdynamic' << '-pthread' << '-Og'

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/toolchain/WPIToolchainPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/toolchain/WPIToolchainPlugin.groovy
@@ -182,6 +182,43 @@ class WPIToolchainPlugin implements Plugin<Project> {
     }
 
     static class WPIToolchainRules extends RuleSource {
+        // Rules require this to be explicitly marked public static final
+        public static final String[] windowsCompilerArgs = ['/EHsc', '/DNOMINMAX', '/Zi', '/FS', '/Zc:inline']
+        public static final String[] windowsCCompilerArgs = ['/Zi', '/FS', '/Zc:inline']
+        public static final String[] windowsReleaseCompilerArgs = ['/O2', '/MD']
+        public static final String[] windowsDebugCompilerArgs = ['/Od', '/MDd']
+        public static final String[] windowsLinkerArgs = ['/DEBUG:FULL']
+        public static final String[] windowsReleaseLinkerArgs = ['/OPT:REF', '/OPT:ICF']
+
+        public static final String[] linuxCrossCompilerArgs = ['-std=c++14', '-Wformat=2', '-Wall', '-Wextra', '-Werror', '-pedantic', '-Wno-psabi', '-g',
+                        '-Wno-unused-parameter', '-Wno-error=deprecated-declarations', '-fPIC', '-rdynamic',
+                        '-pthread']
+        public static final String[] linuxCrossCCompilerArgs = ['-Wformat=2', '-Wall', '-Wextra', '-Werror', '-pedantic', '-Wno-psabi', '-g',
+                            '-Wno-unused-parameter', '-fPIC', '-rdynamic', '-pthread']
+        public static final String[] linuxCrossLinkerArgs = ['-rdynamic', '-pthread', '-ldl']
+        public static final String[] linuxCrossReleaseCompilerArgs = ['-O2']
+        public static final String[] linuxCrossDebugCompilerArgs = ['-Og']
+
+        public static final String[] linuxCompilerArgs = ['-std=c++14', '-Wformat=2', '-Wall', '-Wextra', '-Werror', '-pedantic', '-Wno-psabi', '-g',
+                        '-Wno-unused-parameter', '-Wno-error=deprecated-declarations', '-fPIC', '-rdynamic',
+                        '-pthread']
+        public static final String[] linuxCCompilerArgs = ['-Wformat=2', '-Wall', '-Wextra', '-Werror', '-pedantic', '-Wno-psabi', '-g',
+                            '-Wno-unused-parameter', '-fPIC', '-rdynamic', '-pthread']
+        public static final String[] linuxLinkerArgs = ['-rdynamic', '-pthread', '-ldl']
+        public static final String[] linuxReleaseCompilerArgs = ['-O2']
+        public static final String[] linuxDebugCompilerArgs = ['-O0']
+
+        public static final String[] macCompilerArgs = ['-std=c++14', '-Wall', '-Wextra', '-Werror', '-pedantic-errors', '-fPIC', '-g',
+                        '-Wno-unused-parameter', '-Wno-error=deprecated-declarations', '-Wno-missing-field-initializers',
+                        '-Wno-unused-private-field', '-Wno-unused-const-variable', '-pthread']
+        public static final String[] macCCompilerArgs = ['-Wall', '-Wextra', '-Werror', '-pedantic-errors', '-fPIC', '-g',
+                        '-Wno-unused-parameter', '-Wno-missing-field-initializers', '-Wno-unused-private-field']
+        public static final String[] macObjCppLinkerArgs = ['-std=c++14', '-stdlib=libc++','-fobjc-arc', '-g', '-fPIC', '-Wall', '-Wextra', '-Werror']
+        public static final String[] macReleaseCompilerArgs = ['-O2']
+        public static final String[] macDebugCompilerArgs = ['-O0']
+        public static final String[] macLinkerArgs = ['-framework', 'CoreFoundation', '-framework', 'AVFoundation', '-framework', 'Foundation', '-framework', 'CoreMedia', '-framework', 'CoreVideo']
+
+
         @Defaults
         void addToolchains(NativeToolChainRegistryInternal toolChainRegistry, ServiceRegistry serviceRegistry, ExtensionContainer extContainer) {
             final FileResolver fileResolver = serviceRegistry.get(FileResolver.class);
@@ -287,24 +324,104 @@ class WPIToolchainPlugin implements Plugin<Project> {
         @Mutate
         void addBinaryFlags(BinaryContainer binaries) {
             binaries.withType(NativeBinarySpec, { NativeBinarySpec bin ->
-                if (bin.toolChain in VisualCpp) {
-                    bin.cppCompiler.args << '/std:c++14' << '/FS' << '/EHsc' << '/DNOMINMAX'
-
-                    // Both release and debug should enable the the debugging options
-                    // and MT crt mode. Debugging here is always safe
-                    bin.cppCompiler.args << '/Zi' << '/Zc:inline'
-                    bin.linker.args << '/DEBUG:FULL'
-
-                    // Build release in optimized mode.
-                    if (bin.buildType.name.equals('release')) {
-                        bin.cppCompiler.args << '/O2' << '/MD'
-                        bin.linker.args << '/OPT:REF' << '/OPT:ICF'
+                if (bin.targetPlatform.operatingSystem.isWindows()) {
+                    // Windows
+                    windowsCompilerArgs.each { String arg ->
+                        bin.cppCompiler.args << arg
+                    }
+                    windowsCCompilerArgs.each { String arg ->
+                        bin.cCompiler.args << arg
+                    }
+                    windowsLinkerArgs.each { String arg ->
+                        bin.linker.args << arg
+                    }
+                    if (bin.buildType.name.contains('debug')) {
+                        windowsDebugCompilerArgs.each { String arg ->
+                            bin.cppCompiler.args << arg
+                            bin.cCompiler.args << arg
+                        }
                     } else {
-                        bin.cppCompiler.args << '/MDd'
+                        windowsReleaseCompilerArgs.each { String arg ->
+                            bin.cppCompiler.args << arg
+                            bin.cCompiler.args << arg
+                        }
+                        windowsReleaseLinkerArgs.each { String arg ->
+                            bin.linker.args << arg
+                        }
+                    }
+                } else if (bin.targetPlatform.operatingSystem.isMacOsX()) {
+                    // OSX
+                    macCompilerArgs.each { String arg ->
+                        bin.cppCompiler.args << arg
+                    }
+                    macCCompilerArgs.each { String arg ->
+                        bin.cCompiler.args << arg
+                    }
+                    macObjCppLinkerArgs.each { String arg ->
+                        bin.objcppCompiler.args << arg
+                    }
+                    macLinkerArgs.each { String arg ->
+                        bin.linker.args << arg
+                    }
+                    if (bin.buildType.name.contains('debug')) {
+                        macDebugCompilerArgs.each { String arg ->
+                            bin.cppCompiler.args << arg
+                            bin.cCompiler.args << arg
+                            bin.objcCompiler.args << arg
+                            bin.objcppCompiler.args << arg
+                        }
+                    } else {
+                        macReleaseCompilerArgs.each { String arg ->
+                            bin.cppCompiler.args << arg
+                            bin.cCompiler.args << arg
+                            bin.objcCompiler.args << arg
+                            bin.objcppCompiler.args << arg
+                        }
+                    }
+                } else if (bin.toolChain.name.equals('roborioGcc')) {
+                    // Rio
+                    linuxCrossCompilerArgs.each { String arg ->
+                        bin.cppCompiler.args << arg
+                    }
+                    linuxCrossCCompilerArgs.each { String arg ->
+                        bin.cCompiler.args << arg
+                    }
+                    linuxCrossLinkerArgs.each { String arg ->
+                        bin.linker.args << arg
+                    }
+                    if (bin.buildType.name.contains('debug')) {
+                        linuxCrossDebugCompilerArgs.each { String arg ->
+                            bin.cppCompiler.args << arg
+                            bin.cCompiler.args << arg
+                        }
+                    } else {
+                        linuxCrossReleaseCompilerArgs.each { String arg ->
+                            bin.cppCompiler.args << arg
+                            bin.cCompiler.args << arg
+                        }
                     }
                 } else {
-                    bin.cppCompiler.args << '-std=c++14' << '-g' << '-rdynamic' << '-pthread' << '-Og'
-                    bin.linker.args << '-pthread'
+                    // Linux
+                    linuxCompilerArgs.each { String arg ->
+                        bin.cppCompiler.args << arg
+                    }
+                    linuxCCompilerArgs.each { String arg ->
+                        bin.cCompiler.args << arg
+                    }
+                    linuxLinkerArgs.each { String arg ->
+                        bin.linker.args << arg
+                    }
+                    if (bin.buildType.name.contains('debug')) {
+                        linuxDebugCompilerArgs.each { String arg ->
+                            bin.cppCompiler.args << arg
+                            bin.cCompiler.args << arg
+                        }
+                    } else {
+                        linuxReleaseCompilerArgs.each { String arg ->
+                            bin.cppCompiler.args << arg
+                            bin.cCompiler.args << arg
+                        }
+                    }
                 }
 
                 if (bin.buildType.name.equals('debug')) {


### PR DESCRIPTION
This immensely cleans up simulation, specifically on windows, where it was basically needed

Requires an ET change

I also still need to update the build settings that get used.