### PR TITLE
Fix GString to String type cast failing

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIVendorDepsExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIVendorDepsExtension.groovy
@@ -115,7 +115,7 @@ public class WPIVendorDepsExtension {
 
         return dependencies.findAll { !isIgnored(ignore, it) }.collectMany { JsonDependency dep ->
             dep.javaDependencies.collect { JavaArtifact art ->
-                "${art.groupId}:${art.artifactId}:${getVersion(art.version, wpiExt)}"
+                "${art.groupId}:${art.artifactId}:${getVersion(art.version, wpiExt)}".toString()
             } as List<String>
         }
     }


### PR DESCRIPTION
It seems that the cast from GString to String is failing here. The `toString()` cast is present when returning other dependencies but it isn't present on this one.

Log:
```
class org.codehaus.groovy.runtime.GStringImpl cannot be cast to class java.lang.String (org.codehaus.groovy.runtime.GStringImpl is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader @7823a2f9; java.lang.String is in module java.base of loader 'bootstrap')
Possible causes for this unexpected error include:<ul><li>Gradle's dependency cache may be corrupt (this sometimes occurs after a network connection timeout.)
```