### PR TITLE
Remove generic warning during toolchain compile

### DIFF
--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/GccToolChain.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/GccToolChain.java
@@ -12,7 +12,7 @@ public abstract class GccToolChain extends AbstractGccCompatibleToolChain {
 
     private Project project;
     private ETLogger logger;
-    private ToolchainDescriptor descriptor;
+    private ToolchainDescriptorBase descriptor;
     private ToolchainDiscoverer discoverer;
 
     public GccToolChain(ToolchainOptions options) {
@@ -60,7 +60,7 @@ public abstract class GccToolChain extends AbstractGccCompatibleToolChain {
                     } else {
                         logger.logError("=============================");
                         logger.logErrorHead("No Toolchain Found for " + descriptor.getName());
-                        logger.logErrorHead("Run `./gradlew " + descriptor.installTaskName() + "` to install one!");
+                        logger.logErrorHead("Run `./gradlew " + descriptor.getInstallTaskName() + "` to install one!");
                         logger.logErrorHead("");
                         logger.logErrorHead("You can ignore this error with -Ptoolchain-optional-" + descriptor.getName());
                         logger.logErrorHead("For more information, run with `--info`");
@@ -79,7 +79,7 @@ public abstract class GccToolChain extends AbstractGccCompatibleToolChain {
         return project;
     }
 
-    public ToolchainDescriptor getDescriptor() {
+    public ToolchainDescriptorBase getDescriptor() {
         return descriptor;
     }
 

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/InstallToolchainTask.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/InstallToolchainTask.java
@@ -7,17 +7,17 @@ import org.gradle.internal.os.OperatingSystem;
 
 public class InstallToolchainTask extends DefaultTask {
 
-    private ToolchainDescriptor desc;
+    private ToolchainDescriptorBase desc;
 
     public boolean requiresInstall() {
         return desc.discover() == null || getProject().hasProperty("toolchain-install-force");
     }
 
-    public void setDescriptor(ToolchainDescriptor desc) {
+    public void setDescriptor(ToolchainDescriptorBase desc) {
         this.desc = desc;
     }
 
-    public ToolchainDescriptor getDescriptor() {
+    public ToolchainDescriptorBase getDescriptor() {
         return desc;
     }
 

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainDescriptor.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainDescriptor.java
@@ -1,14 +1,13 @@
 package edu.wpi.first.toolchain;
 
 import org.gradle.api.DomainObjectSet;
-import org.gradle.api.Named;
 import org.gradle.api.NamedDomainObjectSet;
 import org.gradle.api.internal.DefaultDomainObjectSet;
 import org.gradle.api.internal.DefaultNamedDomainObjectSet;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.util.TreeVisitor;
 
-public class ToolchainDescriptor implements Named {
+public class ToolchainDescriptor<T extends GccToolChain> implements ToolchainDescriptorBase {
 
     private String name;
     private String toolchainName;
@@ -17,9 +16,9 @@ public class ToolchainDescriptor implements Named {
     private NamedDomainObjectSet<ToolchainDiscoverer> discoverers;
     private DomainObjectSet<AbstractToolchainInstaller> installers;
 
-    private ToolchainRegistrar registrar;
+    private ToolchainRegistrar<T> registrar;
 
-    public ToolchainDescriptor(String name, String toolchainName, ToolchainRegistrar registrar) {
+    public ToolchainDescriptor(String name, String toolchainName, ToolchainRegistrar<T> registrar) {
         this.name = name;
         this.platforms = null;
         this.optional = false;
@@ -29,26 +28,32 @@ public class ToolchainDescriptor implements Named {
         this.installers = new DefaultDomainObjectSet<AbstractToolchainInstaller>(AbstractToolchainInstaller.class);
     }
 
+    @Override
     public void setToolchainPlatforms(String... platforms) {
         this.platforms = platforms;
     }
 
+    @Override
     public NamedDomainObjectSet<ToolchainDiscoverer> getDiscoverers() {
         return discoverers;
     }
 
+    @Override
     public DomainObjectSet<AbstractToolchainInstaller> getInstallers() {
         return installers;
     }
 
+    @Override
     public ToolchainDiscoverer discover() {
         return discoverers.stream().filter(ToolchainDiscoverer::valid).findFirst().orElse(null);
     }
 
+    @Override
     public AbstractToolchainInstaller getInstaller() {
         return installers.stream().filter(AbstractToolchainInstaller::installable).findFirst().orElse(null);
     }
 
+    @Override
     public void explain(TreeVisitor<String> visitor) {
         for (ToolchainDiscoverer discoverer : discoverers) {
             visitor.node(discoverer.getName());
@@ -58,14 +63,17 @@ public class ToolchainDescriptor implements Named {
         }
     }
 
+    @Override
     public boolean isOptional() {
         return optional;
     }
 
+    @Override
     public void setOptional(boolean optional) {
         this.optional = optional;
     }
 
+    @Override
     public String[] getToolchainPlatforms() {
         return platforms;
     }
@@ -75,15 +83,18 @@ public class ToolchainDescriptor implements Named {
         return name;
     }
 
+    @Override
     public String getToolchainName() {
         return toolchainName;
     }
 
-    public String installTaskName() {
+    @Override
+    public String getInstallTaskName() {
         return "install" + capitalize(getName()) + "Toolchain";
     }
 
-    public ToolchainRegistrar getRegistrar() {
+    @Override
+    public ToolchainRegistrar<T> getRegistrar() {
         return registrar;
     }
 

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainDescriptorBase.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainDescriptorBase.java
@@ -1,0 +1,33 @@
+package edu.wpi.first.toolchain;
+
+import org.gradle.api.DomainObjectSet;
+import org.gradle.api.Named;
+import org.gradle.api.NamedDomainObjectSet;
+import org.gradle.util.TreeVisitor;
+
+public interface ToolchainDescriptorBase extends Named {
+
+    public void setToolchainPlatforms(String... platforms);
+
+    public NamedDomainObjectSet<ToolchainDiscoverer> getDiscoverers();
+
+    public DomainObjectSet<AbstractToolchainInstaller> getInstallers();
+
+    public void explain(TreeVisitor<String> visitor);
+
+    public ToolchainDiscoverer discover();
+
+    public AbstractToolchainInstaller getInstaller();
+
+    public String getToolchainName();
+
+    public String getInstallTaskName();
+
+    public boolean isOptional();
+
+    public void setOptional(boolean optional);
+
+    public String[] getToolchainPlatforms();
+
+    public ToolchainRegistrarBase getRegistrar();
+}

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainExtension.java
@@ -7,14 +7,14 @@ import org.gradle.api.internal.DefaultNamedDomainObjectSet;
 import org.gradle.internal.reflect.DirectInstantiator;
 import org.gradle.util.TreeVisitor;
 
-public class ToolchainExtension extends DefaultNamedDomainObjectSet<ToolchainDescriptor> {
+public class ToolchainExtension extends DefaultNamedDomainObjectSet<ToolchainDescriptorBase> {
 
     private Project project;
 
     public boolean registerPlatforms = true;
 
     public ToolchainExtension(Project project) {
-        super(ToolchainDescriptor.class, DirectInstantiator.INSTANCE);
+        super(ToolchainDescriptorBase.class, DirectInstantiator.INSTANCE);
         this.project = project;
     }
 
@@ -27,7 +27,7 @@ public class ToolchainExtension extends DefaultNamedDomainObjectSet<ToolchainDes
     }
 
     public void explain(TreeVisitor<String> visitor) {
-        for (ToolchainDescriptor desc : this) {
+        for (ToolchainDescriptorBase desc : this) {
             visitor.node(desc.getName());
             visitor.startChildren();
             visitor.node("Selected: " + desc.discover().getName());

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainOptions.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainOptions.java
@@ -15,7 +15,7 @@ public class ToolchainOptions {
 
     public String name;
     public Project project;
-    public ToolchainDescriptor descriptor;
+    public ToolchainDescriptorBase descriptor;
 
     Instantiator instantiator;
     BuildOperationExecutor buildOperationExecutor;

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainPlugin.java
@@ -41,8 +41,8 @@ public class ToolchainPlugin implements Plugin<Project> {
             });
         });
 
-        ext.all((ToolchainDescriptor desc) -> {
-            project.getTasks().register(desc.installTaskName(), InstallToolchainTask.class, (InstallToolchainTask t) -> {
+        ext.all((ToolchainDescriptorBase desc) -> {
+            project.getTasks().register(desc.getInstallTaskName(), InstallToolchainTask.class, (InstallToolchainTask t) -> {
                 t.setGroup("Toolchains");
                 t.setDescription("Install Toolchain for " + desc.getName() + " if installers are available.");
                 t.setDescriptor(desc);

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRegistrar.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRegistrar.java
@@ -7,7 +7,7 @@ import org.gradle.api.Project;
 import org.gradle.internal.reflect.Instantiator;
 import org.gradle.nativeplatform.toolchain.internal.NativeToolChainRegistryInternal;
 
-public class ToolchainRegistrar<T extends GccToolChain> {
+public class ToolchainRegistrar<T extends GccToolChain> implements ToolchainRegistrarBase {
 
     private Class<T> implClass;
     private Project project;
@@ -19,7 +19,8 @@ public class ToolchainRegistrar<T extends GccToolChain> {
         this.logger = ETLoggerFactory.INSTANCE.create("ToolchainRegistrar");
     }
 
-    void register(ToolchainOptions options, NativeToolChainRegistryInternal registry, Instantiator instantiator) {
+    @Override
+    public void register(ToolchainOptions options, NativeToolChainRegistryInternal registry, Instantiator instantiator) {
         NamedDomainObjectFactory<T> factory = new NamedDomainObjectFactory<T>() {
             @Override
             public T create(String name) {

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRegistrarBase.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRegistrarBase.java
@@ -1,0 +1,8 @@
+package edu.wpi.first.toolchain;
+
+import org.gradle.internal.reflect.Instantiator;
+import org.gradle.nativeplatform.toolchain.internal.NativeToolChainRegistryInternal;
+
+interface ToolchainRegistrarBase {
+  void register(ToolchainOptions options, NativeToolChainRegistryInternal registry, Instantiator instantiator);
+}

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/raspbian/RaspbianToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/raspbian/RaspbianToolchainPlugin.java
@@ -25,7 +25,7 @@ public class RaspbianToolchainPlugin implements Plugin<Project> {
 
         ToolchainExtension toolchainExt = project.getExtensions().getByType(ToolchainExtension.class);
 
-        ToolchainDescriptor descriptor = new ToolchainDescriptor(toolchainName, "raspianGcc", new ToolchainRegistrar<RaspbianGcc>(RaspbianGcc.class, project));
+        ToolchainDescriptor<RaspbianGcc> descriptor = new ToolchainDescriptor<>(toolchainName, "raspianGcc", new ToolchainRegistrar<RaspbianGcc>(RaspbianGcc.class, project));
         descriptor.setToolchainPlatforms(NativePlatforms.raspbian);
         descriptor.setOptional(true);
         descriptor.getDiscoverers().all((ToolchainDiscoverer disc) -> {
@@ -49,7 +49,7 @@ public class RaspbianToolchainPlugin implements Plugin<Project> {
         return "arm-" + raspbianVersion + "-linux-gnueabihf-" + toolName + exeSuffix;
     }
 
-    public void populateDescriptor(ToolchainDescriptor descriptor) {
+    public void populateDescriptor(ToolchainDescriptor<RaspbianGcc> descriptor) {
         String raspbianVersion = raspbianExt.toolchainVersion.split("-")[0].toLowerCase();
         File installLoc = toolchainInstallLoc(raspbianVersion);
 

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainPlugin.java
@@ -25,7 +25,7 @@ public class RoboRioToolchainPlugin implements Plugin<Project> {
 
         ToolchainExtension toolchainExt = project.getExtensions().getByType(ToolchainExtension.class);
 
-        ToolchainDescriptor descriptor = new ToolchainDescriptor(toolchainName, "roborioGcc", new ToolchainRegistrar<RoboRioGcc>(RoboRioGcc.class, project));
+        ToolchainDescriptor<RoboRioGcc> descriptor = new ToolchainDescriptor<>(toolchainName, "roborioGcc", new ToolchainRegistrar<RoboRioGcc>(RoboRioGcc.class, project));
         descriptor.setToolchainPlatforms(NativePlatforms.roborio);
         descriptor.setOptional(false);
         descriptor.getDiscoverers().all((ToolchainDiscoverer disc) -> {
@@ -49,7 +49,7 @@ public class RoboRioToolchainPlugin implements Plugin<Project> {
     }
 
 
-    public void populateDescriptor(ToolchainDescriptor descriptor) {
+    public void populateDescriptor(ToolchainDescriptor<RoboRioGcc> descriptor) {
         File frcHomeLoc = new File(new FrcHome(roborioExt.year).get(), "roborio");
         File installLoc = toolchainInstallLoc(roborioExt.year);
 


### PR DESCRIPTION
Required creating a base interface to store in the ToolchainExtension,
but will make usability easier. And no faking generics with object

This should likely wait until 2020, I think this is too big of a change
for 2019.