### PR TITLE
External sim fix, Fixes #291

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/GradleRIOPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/GradleRIOPlugin.groovy
@@ -145,16 +145,18 @@ class GradleRIOPlugin implements Plugin<Project> {
     }
 
     void ensureSingletons(Project project, TaskExecutionGraph graph) {
-        Map<String, Task> singletonMap = [:]
-        graph.getAllTasks().each { Task t ->
+        def allTasks = graph.getAllTasks()
+        def visited = [] as Set<String>
+
+        // Go in reverse - only use the latest version in the task graph (not earliest)
+        allTasks.reverseEach { Task t ->
             if (t instanceof SingletonTask) {
                 String singletonName = (t as SingletonTask).singletonName()
-                if (singletonMap.containsKey(singletonName)) {
-                    Logger.getLogger(this.class).info("Singleton task on graph, disabling: ${t} for ${singletonName}")
-                    t.setEnabled(false)
+                if (visited.add(singletonName)) {
+                    Logger.getLogger(this.class).info("Singleton Task Using: ${t} for ${singletonName}")
                 } else {
-                    Logger.getLogger(this.class).info("Singleton task on graph, using: ${t} for ${singletonName}")
-                    singletonMap.put(singletonName, (Task)t)
+                    Logger.getLogger(this.class).info("Singleton Task Disabling: ${t} for ${singletonName}")
+                    t.setEnabled(false)
                 }
             }
         }

--- a/src/main/groovy/edu/wpi/first/gradlerio/JsonMergeTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/JsonMergeTask.groovy
@@ -12,7 +12,7 @@ class JsonMergeTask extends DefaultTask implements SingletonTask {
     @Internal
     String singletonName = "jsonMerge"
 
-    @InputFile
+    @Internal
     File folder
 
     @OutputFile

--- a/src/main/groovy/edu/wpi/first/gradlerio/JsonMergeTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/JsonMergeTask.groovy
@@ -1,0 +1,38 @@
+package edu.wpi.first.gradlerio
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+class JsonMergeTask extends DefaultTask implements SingletonTask {
+
+    @Internal
+    String singletonName = "jsonMerge"
+
+    @InputFile
+    File folder
+
+    @OutputFile
+    File out
+
+    @TaskAction
+    void merge() {
+        def containerFolder = folder
+        def outfile = out
+
+        if (containerFolder.exists()) {
+            def files = containerFolder.listFiles().findAll {
+                it.isFile() && it.name.endsWith(".json") && it.absolutePath != outfile.absolutePath
+            } as List<File>
+            JsonUtil.mergeArrays(files, outfile)
+        }
+    }
+
+    @Override
+    String singletonName() {
+        return singletonName
+    }
+}

--- a/src/main/groovy/edu/wpi/first/gradlerio/JsonUtil.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/JsonUtil.groovy
@@ -1,0 +1,27 @@
+package edu.wpi.first.gradlerio
+
+import com.google.gson.GsonBuilder
+import groovy.json.JsonOutput
+import groovy.json.JsonSlurper
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class JsonUtil {
+
+    public static void mergeArrays(List<File> files, File outfile) {
+        def slurper = new JsonSlurper()
+        def merged = []
+
+        for (File f : files) {
+            merged.addAll(slurper.parse(f) as List)
+        }
+
+        def gbuilder = new GsonBuilder()
+        gbuilder.setPrettyPrinting()
+        def json = gbuilder.create().toJson(merged)
+
+        outfile.parentFile.mkdirs()
+        outfile.text = json
+    }
+
+}

--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/DebugInfoMergeTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/DebugInfoMergeTask.groovy
@@ -1,0 +1,17 @@
+package edu.wpi.first.gradlerio.frc
+
+import edu.wpi.first.gradlerio.JsonMergeTask
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class DebugInfoMergeTask extends JsonMergeTask {
+
+    public static final String CONTAINER_FOLDER = "debug/riopartial"
+    public static final String OUTPUT_FILE = "debug/debuginfo.json"
+
+    DebugInfoMergeTask() {
+        this.out = new File(project.rootProject.buildDir, OUTPUT_FILE)
+        this.folder = new File(project.rootProject.buildDir, CONTAINER_FOLDER)
+        this.singletonName = "mergeDebugInfo"
+    }
+}

--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/DebugInfoTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/DebugInfoTask.groovy
@@ -4,12 +4,16 @@ import com.google.gson.GsonBuilder
 import groovy.transform.CompileStatic
 import jaci.gradle.deploy.artifact.Artifact
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 @CompileStatic
 class DebugInfoTask extends DefaultTask {
 
     List<Closure> extraArtifacts = []
+
+    @OutputFile
+    File outfile = new File(project.rootProject.buildDir, "${DebugInfoMergeTask.CONTAINER_FOLDER}/${project.name}.json")
 
     @TaskAction
     void writeDebugInfo() {
@@ -18,7 +22,7 @@ class DebugInfoTask extends DefaultTask {
             if (art instanceof FRCJavaArtifact) {
                 art.targets.all { String target ->
                     cfg << [
-                        artifact: art.name,
+                        artifact: "${art.name} (in project ${project.name})".toString(),
                         target: target,
                         debugfile: "${art.name}_${target}.debugconfig".toString(),
                         project: project.name,
@@ -28,7 +32,7 @@ class DebugInfoTask extends DefaultTask {
             } else if (art instanceof FRCNativeArtifact) {
                 art.targets.all { String target ->
                     cfg << [
-                        artifact: art.name,
+                        artifact: "${art.name} (in project ${project.name})".toString(),
                         target: target,
                         component: (art as FRCNativeArtifact).component,
                         debugfile: "${art.name}_${target}.debugconfig".toString(),
@@ -42,12 +46,11 @@ class DebugInfoTask extends DefaultTask {
             }
         }
 
-        def file = new File(project.buildDir, "debug/debuginfo.json")
-        file.parentFile.mkdirs()
+        outfile.parentFile.mkdirs()
 
         def gbuilder = new GsonBuilder()
         gbuilder.setPrettyPrinting()
-        file.text = gbuilder.create().toJson(cfg)
+        outfile.text = gbuilder.create().toJson(cfg)
     }
 
 }

--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCPlugin.groovy
@@ -9,6 +9,7 @@ import jaci.gradle.deploy.artifact.ArtifactDeployTask
 import jaci.gradle.deploy.artifact.CommandArtifact
 import jaci.gradle.deploy.artifact.JavaArtifact
 import jaci.gradle.deploy.context.DeployContext
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -35,8 +36,14 @@ class FRCPlugin implements Plugin<Project> {
         project.pluginManager.apply(EmbeddedTools)
         project.pluginManager.apply(RiologPlugin)
 
-        def debugInfoLazy = project.tasks.register("writeDebugInfo", DebugInfoTask)
+        def debugInfoLazy = project.tasks.register("writeDebugInfo", DebugInfoTask, { DebugInfoTask t ->
+            t.finalizedBy(project.tasks.withType(DebugInfoMergeTask))
+        } as Action<DebugInfoTask>)
         def frcExt = project.extensions.create("frc", FRCExtension, project)
+
+        project.tasks.register("mergeDebugInfo", DebugInfoMergeTask, { DebugInfoMergeTask t ->
+            t.dependsOn(debugInfoLazy)
+        } as Action<DebugInfoMergeTask>)
 
         project.tasks.withType(ArtifactDeployTask).configureEach { ArtifactDeployTask t ->
             t.dependsOn(debugInfoLazy)

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/ExternalSimulationMergeTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/ExternalSimulationMergeTask.groovy
@@ -1,33 +1,18 @@
 package edu.wpi.first.gradlerio.test
 
-import com.google.gson.Gson
-import com.google.gson.JsonParser
-import com.google.gson.stream.JsonWriter
-import edu.wpi.first.gradlerio.JsonUtil
-import edu.wpi.first.gradlerio.SingletonTask
+import edu.wpi.first.gradlerio.JsonMergeTask
 import groovy.transform.CompileStatic
-import org.gradle.api.DefaultTask
-import org.gradle.api.Task
-import org.gradle.api.tasks.TaskAction
 
 @CompileStatic
-class ExternalSimulationMergeTask extends DefaultTask implements SingletonTask {
+class ExternalSimulationMergeTask extends JsonMergeTask {
 
-    @TaskAction
-    void merge() {
-        def containerFolder = new File(project.rootProject.buildDir, "debug/partial")
-        def outfile = new File(project.rootProject.buildDir, "debug/desktopinfo.json")
+    public static final String CONTAINER_FOLDER = "debug/partial"
+    public static final String OUTPUT_FILE = "debug/desktopinfo.json"
 
-        if (containerFolder.exists()) {
-            def files = containerFolder.listFiles().findAll {
-                it.isFile() && it.name.endsWith(".json") && it.absolutePath != outfile.absolutePath
-            } as List<File>
-            JsonUtil.mergeArrays(files, outfile)
-        }
+    ExternalSimulationMergeTask() {
+        this.out = new File(project.rootProject.buildDir, OUTPUT_FILE)
+        this.folder = new File(project.rootProject.buildDir, CONTAINER_FOLDER)
+        this.singletonName = "mergeExternalSim"
     }
 
-    @Override
-    String singletonName() {
-        return "mergeExternalSim"
-    }
 }

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/ExternalSimulationMergeTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/ExternalSimulationMergeTask.groovy
@@ -1,0 +1,33 @@
+package edu.wpi.first.gradlerio.test
+
+import com.google.gson.Gson
+import com.google.gson.JsonParser
+import com.google.gson.stream.JsonWriter
+import edu.wpi.first.gradlerio.JsonUtil
+import edu.wpi.first.gradlerio.SingletonTask
+import groovy.transform.CompileStatic
+import org.gradle.api.DefaultTask
+import org.gradle.api.Task
+import org.gradle.api.tasks.TaskAction
+
+@CompileStatic
+class ExternalSimulationMergeTask extends DefaultTask implements SingletonTask {
+
+    @TaskAction
+    void merge() {
+        def containerFolder = new File(project.rootProject.buildDir, "debug/partial")
+        def outfile = new File(project.rootProject.buildDir, "debug/desktopinfo.json")
+
+        if (containerFolder.exists()) {
+            def files = containerFolder.listFiles().findAll {
+                it.isFile() && it.name.endsWith(".json") && it.absolutePath != outfile.absolutePath
+            } as List<File>
+            JsonUtil.mergeArrays(files, outfile)
+        }
+    }
+
+    @Override
+    String singletonName() {
+        return "mergeExternalSim"
+    }
+}

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/ExternalSimulationTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/ExternalSimulationTask.groovy
@@ -1,0 +1,5 @@
+package edu.wpi.first.gradlerio.test
+
+import org.gradle.api.DefaultTask
+
+class ExternalSimulationTask extends DefaultTask { }

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/JavaExternalSimulationTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/JavaExternalSimulationTask.groovy
@@ -12,7 +12,7 @@ import org.gradle.jvm.tasks.Jar
 class JavaExternalSimulationTask extends ExternalSimulationTask {
 
     @OutputFile
-    File outfile = new File(project.rootProject.buildDir, "debug/partial/${project.name}_java.json")
+    File outfile = new File(project.rootProject.buildDir, "${ExternalSimulationMergeTask.CONTAINER_FOLDER}/${project.name}_java.json")
 
     @TaskAction
     void create() {

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/JavaExternalSimulationTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/JavaExternalSimulationTask.groovy
@@ -4,11 +4,16 @@ import com.google.gson.GsonBuilder
 import edu.wpi.first.gradlerio.test.JavaTestPlugin
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.jvm.tasks.Jar
 
 @CompileStatic
-class JavaExternalSimulationTask extends DefaultTask {
+class JavaExternalSimulationTask extends ExternalSimulationTask {
+
+    @OutputFile
+    File outfile = new File(project.rootProject.buildDir, "debug/partial/${project.name}_java.json")
+
     @TaskAction
     void create() {
         def cfgs = []
@@ -37,7 +42,6 @@ class JavaExternalSimulationTask extends DefaultTask {
         gbuilder.setPrettyPrinting()
         def json = gbuilder.create().toJson(cfgs)
 
-        def outfile = new File(project.buildDir, "debug/desktopinfo.json")
         outfile.parentFile.mkdirs()
         outfile.text = json
     }

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/JavaExternalSimulationTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/JavaExternalSimulationTask.groovy
@@ -30,7 +30,7 @@ class JavaExternalSimulationTask extends ExternalSimulationTask {
 
             def cfg = [:]
 
-            cfg['name'] = jar.baseName
+            cfg['name'] = "${jar.baseName} (in project ${project.name})".toString()
             cfg['file'] = jar.outputs.files.singleFile.absolutePath
             cfg['extensions'] = extensions
             cfg['librarydir'] = libraryDir

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/JavaTestPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/JavaTestPlugin.groovy
@@ -26,6 +26,7 @@ class JavaTestPlugin implements Plugin<Project> {
 
             task.dependsOn("extractTestJNI")
             task.dependsOn(project.tasks.withType(Jar))
+            task.finalizedBy(project.tasks.withType(ExternalSimulationMergeTask))
         } as Action<JavaExternalSimulationTask>)
 
         project.tasks.register("simulateJava", JavaSimulationTask, { JavaSimulationTask task ->
@@ -34,7 +35,6 @@ class JavaTestPlugin implements Plugin<Project> {
 
             task.dependsOn("extractTestJNI")
             task.dependsOn(project.tasks.withType(Jar))
-            task.finalizedBy(project.tasks.withType(ExternalSimulationMergeTask))
         } as Action<JavaSimulationTask>)
 
         // Java Unit Tests

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/JavaTestPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/JavaTestPlugin.groovy
@@ -34,6 +34,7 @@ class JavaTestPlugin implements Plugin<Project> {
 
             task.dependsOn("extractTestJNI")
             task.dependsOn(project.tasks.withType(Jar))
+            task.finalizedBy(project.tasks.withType(ExternalSimulationMergeTask))
         } as Action<JavaSimulationTask>)
 
         // Java Unit Tests

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/NativeExternalSimulationTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/NativeExternalSimulationTask.groovy
@@ -21,7 +21,7 @@ class NativeExternalSimulationTask extends ExternalSimulationTask {
     List<NativeExecutableBinarySpec> binaries = []
 
     @OutputFile
-    File outfile = new File(project.rootProject.buildDir, "debug/partial/${project.name}_native.json")
+    File outfile = new File(project.rootProject.buildDir, "${ExternalSimulationMergeTask.CONTAINER_FOLDER}/${project.name}_native.json")
 
     @TaskAction
     void create() {

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/NativeExternalSimulationTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/NativeExternalSimulationTask.groovy
@@ -5,6 +5,7 @@ import groovy.transform.CompileStatic
 import jaci.gradle.nativedeps.DelegatedDependencySet
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.language.nativeplatform.HeaderExportingSourceSet
 import org.gradle.nativeplatform.NativeDependencySet
@@ -15,9 +16,12 @@ import org.gradle.nativeplatform.toolchain.Clang
 import java.nio.file.Paths
 
 @CompileStatic
-class NativeExternalSimulationTask extends DefaultTask {
+class NativeExternalSimulationTask extends ExternalSimulationTask {
     @Internal
     List<NativeExecutableBinarySpec> binaries = []
+
+    @OutputFile
+    File outfile = new File(project.rootProject.buildDir, "debug/partial/${project.name}_native.json")
 
     @TaskAction
     void create() {
@@ -26,7 +30,7 @@ class NativeExternalSimulationTask extends DefaultTask {
         for (NativeExecutableBinarySpec binary : binaries) {
             def cfg = [:]
             def installTask = (InstallExecutable)binary.tasks.install
-            cfg['name'] = "${binary.component.name} (${binary.buildType})".toString()
+            cfg['name'] = "${binary.component.name} (${binary.buildType.name})".toString()
             cfg['extensions'] = extensions
             cfg['launchfile'] = Paths.get(installTask.installDirectory.asFile.get().toString(), 'lib', installTask.executableFile.asFile.get().name).toString()
             cfg['clang'] = binary.toolChain in Clang
@@ -62,7 +66,6 @@ class NativeExternalSimulationTask extends DefaultTask {
         gbuilder.setPrettyPrinting()
         def json = gbuilder.create().toJson(cfgs)
 
-        def outfile = new File(project.buildDir, "debug/desktopinfo.json")
         outfile.parentFile.mkdirs()
         outfile.text = json
     }

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/NativeExternalSimulationTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/NativeExternalSimulationTask.groovy
@@ -30,7 +30,7 @@ class NativeExternalSimulationTask extends ExternalSimulationTask {
         for (NativeExecutableBinarySpec binary : binaries) {
             def cfg = [:]
             def installTask = (InstallExecutable)binary.tasks.install
-            cfg['name'] = "${binary.component.name} (${binary.buildType.name})".toString()
+            cfg['name'] = "${binary.component.name} (in project ${project.name})".toString()
             cfg['extensions'] = extensions
             cfg['launchfile'] = Paths.get(installTask.installDirectory.asFile.get().toString(), 'lib', installTask.executableFile.asFile.get().name).toString()
             cfg['clang'] = binary.toolChain in Clang

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/NativeTestPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/NativeTestPlugin.groovy
@@ -43,6 +43,8 @@ class NativeTestPlugin implements Plugin<Project> {
         project.tasks.register("simulateExternalCpp", NativeExternalSimulationTask, { NativeExternalSimulationTask task ->
             task.group = "GradleRIO"
             task.description = "Simulate External Task for native executable. Exports a JSON file for use by editors / tools"
+
+            task.finalizedBy(project.tasks.withType(ExternalSimulationMergeTask))
         } as Action<NativeExternalSimulationTask>)
     }
 
@@ -81,7 +83,9 @@ class NativeTestPlugin implements Plugin<Project> {
             def project = extCont.getByType(GradleRIOPlugin.ProjectWrapper).project
             components.withType(NativeExecutableSpec).each { NativeExecutableSpec spec ->
                 spec.binaries.withType(NativeExecutableBinarySpec).each { NativeExecutableBinarySpec bin ->
-                    if (bin.targetPlatform.operatingSystem.current && !bin.targetPlatform.name.equals(NativePlatforms.roborio)) {
+                    if (bin.targetPlatform.operatingSystem.current &&
+                            bin.targetPlatform.name.equals(NativePlatforms.desktop) &&
+                            bin.buildType.name.equals('debug')) {
                         mainTask.binaries << bin
                         mainTask.dependsOn bin.tasks.install
                     }

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/TestPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/TestPlugin.groovy
@@ -2,6 +2,7 @@ package edu.wpi.first.gradlerio.test
 
 import groovy.transform.CompileStatic
 import jaci.gradle.toolchains.ToolchainsPlugin
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.tasks.util.PatternFilterable
@@ -19,6 +20,10 @@ class TestPlugin implements Plugin<Project> {
         project.plugins.withType(ToolchainsPlugin).all {
             project.pluginManager.apply(NativeTestPlugin)
         }
+
+        project.tasks.register("externalSimulate", ExternalSimulationMergeTask, { ExternalSimulationMergeTask t ->
+            t.dependsOn(project.tasks.withType(ExternalSimulationTask))
+        } as Action<ExternalSimulationMergeTask>)
     }
 
     static List<String> getHALExtensions(Project project) {


### PR DESCRIPTION
Makes sim work better in multiproject builds / builds with multiple simulation targets. Likewise for RoboRIO debug configurations.

Correctly labels sim / debug candidates with their project name for identification, and makes all projects place it into the rootProject such that vscode can find it. 

Also adds a small fix to singleton tasks, wherein the last task is the only one executed, not the first (required for tasks that 'merge' files together)