### PR TITLE
Download jre .ipk preemptively, fixes #294

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCJREArtifact.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCJREArtifact.groovy
@@ -14,8 +14,8 @@ class FRCJREArtifact extends MavenArtifact {
 
     FRCJREArtifact(String name, Project project) {
         super(name, project)
-        configuration = project.configurations.create(name + 'frcjre')
-        dependency = project.dependencies.add(name + 'frcjre', project.extensions.getByType(WPIExtension).jreArtifactLocation)
+        configuration = project.configurations.create(configuration())
+        dependency = project.dependencies.add(configuration(), project.extensions.getByType(WPIExtension).jreArtifactLocation)
 
         onlyIf = { DeployContext ctx ->
             buildRequiresJre.apply(ctx) && jreMissing(ctx)
@@ -33,6 +33,10 @@ class FRCJREArtifact extends MavenArtifact {
             ctx.execute('opkg remove frc2019-openjdk*; opkg install /tmp/frcjre.ipk; rm /tmp/frcjre.ipk')
             ctx.logger.log('JRE Deployed!')
         }
+    }
+
+    String configuration() {
+        return name + 'frcjre'
     }
 
     boolean jreMissing(DeployContext ctx) {

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIDependenciesPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIDependenciesPlugin.groovy
@@ -1,11 +1,17 @@
 package edu.wpi.first.gradlerio.wpi.dependencies
 
+import edu.wpi.first.gradlerio.frc.FRCJREArtifact
 import edu.wpi.first.gradlerio.wpi.WPIExtension
 import groovy.transform.CompileStatic
+import jaci.gradle.deploy.DeployExtension
+import jaci.gradle.deploy.artifact.Artifact
 import jaci.gradle.log.ETLogger
 import jaci.gradle.log.ETLoggerFactory
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.Task
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.jvm.tasks.Jar
 
@@ -32,22 +38,38 @@ class WPIDependenciesPlugin implements Plugin<Project> {
         def wpi = project.extensions.getByType(WPIExtension)
         wpi.deps.vendor.loadAll()
 
-        project.tasks.withType(Jar) { Jar jarTask ->
-            jarTask.doFirst {
+        // We need to register our own task for this, since .doFirst on compileJava (or any Jar task), won't work
+        // if it's up-to-date
+        def lazyPreempt = project.tasks.register('downloadDepsPreemptively', DefaultTask, { Task t ->
+            t.doFirst {
                 // On build, download all libs that will be needed for deploy to lessen the cases where the user has to
                 // run an online deploy dry or downloadAll task.
-                downloadRoborioDepsForDeploy(project, logger)
+                downloadDepsPreemptively(project, logger)
             }
+        } as Action<Task>)
+
+        project.tasks.withType(Jar) { Jar jarTask ->
+            jarTask.dependsOn(lazyPreempt)
         }
     }
 
-    void downloadRoborioDepsForDeploy(Project project, ETLogger logger) {
-        ['nativeLib', 'nativeZip'].each {
+    void downloadDepsPreemptively(Project project, ETLogger logger) {
+        def configs = ['nativeLib', 'nativeZip']
+
+        project.extensions.getByType(DeployExtension).artifacts.each { Artifact art ->
+            if (art instanceof FRCJREArtifact) {
+                def cfgName = ((FRCJREArtifact)art).configuration()
+                logger.info("Found JRE Configuration: " + cfgName)
+                configs.add(cfgName);
+            }
+        }
+
+        configs.each {
             def cfg = project.configurations.getByName(it)
             if (cfg.canBeResolved) {
-                logger.info("Resolving RoboRIO Deps Configuration: " + cfg.getName())
+                logger.info("Resolving Deps Configuration: " + cfg.getName())
                 cfg.resolvedConfiguration.resolvedArtifacts.each { ResolvedArtifact art ->
-                    art.file
+                    logger.info(' ->' + art.file)
                 }
             } else {
                 logger.info("Can't resolve: " + cfg.getName())


### PR DESCRIPTION
Also fixes a newly-discovered bug where if the jar task was up to date (no changes in .java files), missing JNI deps wouldn't redownload 