### PR TITLE
Add support for easily configurable toolchains

### DIFF
--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainPlugin.java
@@ -41,7 +41,7 @@ public class ToolchainPlugin implements Plugin<Project> {
             });
         });
 
-        ext.all((ToolchainDescriptor desc) -> {
+        ext.getToolchainDescriptors().all((ToolchainDescriptor desc) -> {
             project.getTasks().register(desc.installTaskName(), InstallToolchainTask.class, (InstallToolchainTask t) -> {
                 t.setGroup("Toolchains");
                 t.setDescription("Install Toolchain for " + desc.getName() + " if installers are available.");

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRules.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/ToolchainRules.java
@@ -69,7 +69,7 @@ public class ToolchainRules extends RuleSource {
     }
 
     @Mutate
-    void addDefaultPlatforms(final PlatformContainer platforms, final ExtensionContainer extContainer) {
+    void addDefaultPlatforms(final ExtensionContainer extContainer, final PlatformContainer platforms) {
         final ToolchainExtension ext = extContainer.getByType(ToolchainExtension.class);
 
         if (ext.registerPlatforms) {

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/configurable/ConfigurableGcc.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/configurable/ConfigurableGcc.java
@@ -1,0 +1,15 @@
+package edu.wpi.first.toolchain.configurable;
+
+import edu.wpi.first.toolchain.GccToolChain;
+import edu.wpi.first.toolchain.ToolchainOptions;
+
+public class ConfigurableGcc extends GccToolChain {
+  public ConfigurableGcc(ToolchainOptions options) {
+    super(options);
+  }
+
+  @Override
+  protected String getTypeName() {
+    return this.getName() + "ConfiguredGcc";
+  }
+}

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/configurable/CrossCompilerConfiguration.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/configurable/CrossCompilerConfiguration.java
@@ -1,0 +1,22 @@
+package edu.wpi.first.toolchain.configurable;
+
+import org.gradle.api.Named;
+
+import edu.wpi.first.toolchain.ToolchainDescriptor;
+
+public interface CrossCompilerConfiguration extends Named {
+  void setArchitecture(String arch);
+  String getArchitecture();
+
+  void setOperatingSystem(String os);
+  String getOperatingSystem();
+
+  void setCompilerPrefix(String prefix);
+  String getCompilerPrefix();
+
+  void setOptional(boolean optional);
+  boolean getOptional();
+
+  void setToolchainDescriptor(ToolchainDescriptor descriptor);
+  ToolchainDescriptor getToolchainDescriptor();
+}

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/configurable/DefaultCrossCompilerConfiguration.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/configurable/DefaultCrossCompilerConfiguration.java
@@ -1,0 +1,87 @@
+package edu.wpi.first.toolchain.configurable;
+
+import edu.wpi.first.toolchain.ToolchainDescriptor;
+
+public class DefaultCrossCompilerConfiguration implements CrossCompilerConfiguration {
+  private final String name;
+  private String architecture;
+  private String operatingSystem;
+  private String compilerPrefix;
+  private boolean optional;
+  private ToolchainDescriptor descriptor;
+
+  public DefaultCrossCompilerConfiguration(String name) {
+    this.name = name;
+  }
+
+  public DefaultCrossCompilerConfiguration(String name, ToolchainDescriptor descriptor) {
+    this.name = name;
+    this.descriptor = descriptor;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * @return the architecture
+   */
+  public String getArchitecture() {
+    return architecture;
+  }
+
+  /**
+   * @param architecture the architecture to set
+   */
+  public void setArchitecture(String architecture) {
+    this.architecture = architecture;
+  }
+
+  /**
+   * @return the operatingSystem
+   */
+  public String getOperatingSystem() {
+    return operatingSystem;
+  }
+
+  /**
+   * @param operatingSystem the operatingSystem to set
+   */
+  public void setOperatingSystem(String operatingSystem) {
+    this.operatingSystem = operatingSystem;
+  }
+
+  /**
+   * @return the compilerPrefix
+   */
+  public String getCompilerPrefix() {
+    return compilerPrefix;
+  }
+
+  /**
+   * @param compilerPrefix the compilerPrefix to set
+   */
+  public void setCompilerPrefix(String compilerPrefix) {
+    this.compilerPrefix = compilerPrefix;
+  }
+
+  @Override
+  public void setOptional(boolean optional) {
+    this.optional = optional;
+  }
+
+  @Override
+  public boolean getOptional() {
+    return optional;
+  }
+
+  @Override
+  public void setToolchainDescriptor(ToolchainDescriptor optional) {
+    this.descriptor = optional;
+  }
+
+  @Override
+  public ToolchainDescriptor getToolchainDescriptor() {
+    return descriptor;
+  }
+}

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/raspbian/RaspbianToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/raspbian/RaspbianToolchainPlugin.java
@@ -1,6 +1,9 @@
 package edu.wpi.first.toolchain.raspbian;
 
 import edu.wpi.first.toolchain.*;
+import edu.wpi.first.toolchain.configurable.CrossCompilerConfiguration;
+import edu.wpi.first.toolchain.configurable.DefaultCrossCompilerConfiguration;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -32,7 +35,14 @@ public class RaspbianToolchainPlugin implements Plugin<Project> {
             disc.configureVersions(raspbianExt.versionLow, raspbianExt.versionHigh);
         });
 
-        toolchainExt.add(descriptor);
+        CrossCompilerConfiguration configuration = new DefaultCrossCompilerConfiguration(NativePlatforms.raspbian, descriptor);
+        configuration.setArchitecture("arm");
+        configuration.setOperatingSystem("linux");
+        configuration.setOptional(true);
+        configuration.setCompilerPrefix("");
+
+        toolchainExt.getCrossCompilers().add(configuration);
+
 
         project.afterEvaluate((Project proj) -> {
             populateDescriptor(descriptor);

--- a/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainPlugin.java
+++ b/ToolchainPlugin/src/main/java/edu/wpi/first/toolchain/roborio/RoboRioToolchainPlugin.java
@@ -1,6 +1,9 @@
 package edu.wpi.first.toolchain.roborio;
 
 import edu.wpi.first.toolchain.*;
+import edu.wpi.first.toolchain.configurable.CrossCompilerConfiguration;
+import edu.wpi.first.toolchain.configurable.DefaultCrossCompilerConfiguration;
+
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -32,7 +35,13 @@ public class RoboRioToolchainPlugin implements Plugin<Project> {
             disc.configureVersions(roborioExt.versionLow, roborioExt.versionHigh);
         });
 
-        toolchainExt.add(descriptor);
+        CrossCompilerConfiguration configuration = new DefaultCrossCompilerConfiguration(NativePlatforms.roborio, descriptor);
+        configuration.setArchitecture("arm");
+        configuration.setOperatingSystem("linux");
+        configuration.setOptional(false);
+        configuration.setCompilerPrefix("");
+
+        toolchainExt.getCrossCompilers().add(configuration);
 
         project.afterEvaluate((Project proj) -> {
             populateDescriptor(descriptor);

--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCNativeArtifact.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCNativeArtifact.groovy
@@ -134,7 +134,7 @@ class FRCNativeArtifact extends NativeArtifact {
                 def target = ip.host + ":" + debugPort
 //                def toolchainD = project.plugins.getPlugin(WPIToolchainPlugin.class).discoverRoborioToolchain()
 
-                def toolchainD = project.extensions.getByType(ToolchainExtension).getByName(RoboRioToolchainPlugin.toolchainName).discover()
+                def toolchainD = project.extensions.getByType(ToolchainExtension).toolchainDescriptors.getByName(RoboRioToolchainPlugin.toolchainName).discover()
                 def gdbpath = toolchainD.gdbFile().get().absolutePath
                 def sysroot = toolchainD.sysroot().orElse(null).absolutePath
 

--- a/src/main/groovy/edu/wpi/first/gradlerio/ide/EditorConfigurationTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/ide/EditorConfigurationTask.groovy
@@ -24,7 +24,7 @@ class EditorConfigurationTask extends DefaultTask {
         def cfg = [:]
 
         // Compiler
-        def toolchainD = project.extensions.getByType(ToolchainExtension).getByName(RoboRioToolchainPlugin.toolchainName).discover()
+        def toolchainD = project.extensions.getByType(ToolchainExtension).toolchainDescriptors.getByName(RoboRioToolchainPlugin.toolchainName).discover()
         def dCompiler = [
             toolchainDir     : toolchainD.rootDir().get().absolutePath,
             gdbPath          : toolchainD.gdbFile().get().absolutePath,


### PR DESCRIPTION
Will add examples, but a basic path based toolchain is configurable from the DSL

In addition, the Rio and Raspbian toolchains use this DSL, as the DSL is used to create the  native platforms in the rules.