### PR TITLE
Fix two Rio JRE slowdown issues (string concat and GC)

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCJavaArtifact.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCJavaArtifact.groovy
@@ -34,7 +34,7 @@ class FRCJavaArtifact extends JavaArtifact {
     String debugFlags = "-XX:+UsePerfData -agentlib:jdwp=transport=dt_socket,address=0.0.0.0:${debugPort},server=y,suspend=y"
 
     def robotCommand = {
-        "/usr/local/frc/JRE/bin/java -Djava.library.path=${FRCPlugin.LIB_DEPLOY_DIR} ${jvmArgs.join(" ")} ${debug ? debugFlags : ""} -jar \"<<BINARY>>\" ${arguments.join(" ")}"
+        "/usr/local/frc/JRE/bin/java -Djava.library.path=${FRCPlugin.LIB_DEPLOY_DIR} -Djava.lang.invoke.stringConcat=BC_SB –XX:+UseConcMarkSweepGC ${jvmArgs.join(" ")} ${debug ? debugFlags : ""} -jar \"<<BINARY>>\" ${arguments.join(" ")}"
     }
 
     @Override


### PR DESCRIPTION
Change java.lang.invoke.stringConcat to BC_SB.  See https://www.chiefdelphi.com/t/improbable-java-slow-down-in-combining-doubles-and-strings/350331/20

Change to CMS garbage collector.  See https://www.chiefdelphi.com/t/timedrobot-loop-overruns-and-inconsistent-loop-timing-java/348953/25