### PR TITLE
Clean up how JNI is added to the project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     compile 'com.google.code.gson:gson:2.2.4'
     compile 'edu.wpi.first:gradle-cpp-vscode:0.9.4'
 
-    compile 'edu.wpi.first:native-utils:2020.0.4'
+    compile 'edu.wpi.first:native-utils:2020.0.5'
 
     compile 'com.jcraft:jsch:0.1.53'
 

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -38,9 +38,14 @@ deploy {
 // Also defines JUnit 4.
 dependencies {
     compile wpi.deps.wpilib()
+    nativeZip wpi.deps.wpilibJni(wpi.platforms.roborio)
+    nativeDesktopZip wpi.deps.wpilibJni(wpi.platforms.desktop)
+
+
     compile wpi.deps.vendor.java()
     nativeZip wpi.deps.vendor.jni(wpi.platforms.roborio)
     nativeDesktopZip wpi.deps.vendor.jni(wpi.platforms.desktop)
+
     testCompile 'junit:junit:4.12'
 }
 

--- a/examples/kotlin/build.gradle
+++ b/examples/kotlin/build.gradle
@@ -41,6 +41,10 @@ repositories {
 // Defining my dependencies. In this case, WPILib (+ friends)
 dependencies {
     compile wpi.deps.wpilib()
+    nativeZip wpi.deps.wpilibJni(wpi.platforms.roborio)
+    nativeDesktopZip wpi.deps.wpilibJni(wpi.platforms.desktop)
+
+
     compile wpi.deps.vendor.java()
     nativeZip wpi.deps.vendor.jni(wpi.platforms.roborio)
     nativeDesktopZip wpi.deps.vendor.jni(wpi.platforms.desktop)

--- a/src/main/groovy/edu/wpi/first/gradlerio/GradleRIOPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/GradleRIOPlugin.groovy
@@ -48,6 +48,12 @@ class GradleRIOPlugin implements Plugin<Project> {
         project.configurations.maybeCreate("nativeDesktopLib")
         project.configurations.maybeCreate("nativeDesktopZip")
 
+        project.configurations.maybeCreate("nativeRaspbianLib")
+        project.configurations.maybeCreate("nativeRaspbianZip")
+
+        project.configurations.maybeCreate("nativeAarch64BionicLib")
+        project.configurations.maybeCreate("nativeAarch64BionicZip")
+
         project.pluginManager.apply(EmbeddedTools)
         project.pluginManager.apply(FRCPlugin)
         project.pluginManager.apply(WPIPlugin)

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
@@ -40,10 +40,6 @@ class WPIExtension {
     String toolchainVersionLow = "6.3"
     String toolchainVersionHigh = "6.3"
 
-    // Set to true to use debug JNI
-    // Might require extra libraries (especially on windows)
-    boolean debugSimJNI = false
-
     WPIMavenExtension maven
     WPIDepsExtension deps
 

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIDepsExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIDepsExtension.groovy
@@ -34,16 +34,6 @@ public class WPIDepsExtension {
     }
 
     List<String> wpilib() {
-        wpilibJni().each {
-            wpi.project.dependencies.add("nativeZip", it)
-        }
-        wpilibDesktopJni().each {
-            wpi.project.dependencies.add("nativeDesktopZip", it)
-        }
-        return wpilibJars()
-    }
-
-    List<String> wpilibJars() {
         return ["edu.wpi.first.wpilibj:wpilibj-java:${wpi.wpilibVersion}".toString(),
                 "edu.wpi.first.ntcore:ntcore-java:${wpi.wpilibVersion}".toString(),
                 "edu.wpi.first.wpiutil:wpiutil-java:${wpi.wpilibVersion}".toString(),
@@ -63,33 +53,43 @@ public class WPIDepsExtension {
                 "edu.wpi.first.hal:hal-java:${wpi.wpilibVersion}:sources".toString()]
     }
 
-    List<String> wpilibJni() {
+    List<String> wpilibJni(String platform) {
+        return wpilibJniInternal(false, platform)
+    }
+
+    List<String> wpilibJniDebug(String platform) {
+        return wpilibJniInternal(true, platform);
+    }
+
+    List<String> wpilibJniInternal(boolean debug, String platform) {
+        def debugString = debug ? "debug" : ""
+
         // Note: we use -cpp artifacts instead of -jni artifacts as the -cpp ones are linked with shared
         // libraries, while the -jni ones are standalone (have static libs embedded).
-        return ["edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:${wpi.platforms.roborio}debug@zip".toString(),
-                "edu.wpi.first.hal:hal-cpp:${wpi.wpilibVersion}:${wpi.platforms.roborio}debug@zip".toString(),
-                "edu.wpi.first.wpiutil:wpiutil-cpp:${wpi.wpilibVersion}:${wpi.platforms.roborio}debug@zip".toString(),
-                "edu.wpi.first.ntcore:ntcore-cpp:${wpi.wpilibVersion}:${wpi.platforms.roborio}debug@zip".toString(),
-                "edu.wpi.first.cscore:cscore-cpp:${wpi.wpilibVersion}:${wpi.platforms.roborio}debug@zip".toString()]
+        return ["edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:${platform}${debugString}@zip".toString(),
+                "edu.wpi.first.hal:hal-cpp:${wpi.wpilibVersion}:${platform}${debugString}@zip".toString(),
+                "edu.wpi.first.wpiutil:wpiutil-cpp:${wpi.wpilibVersion}:${platform}${debugString}@zip".toString(),
+                "edu.wpi.first.ntcore:ntcore-cpp:${wpi.wpilibVersion}:${platform}${debugString}@zip".toString(),
+                "edu.wpi.first.cscore:cscore-cpp:${wpi.wpilibVersion}:${platform}${debugString}@zip".toString()]
     }
 
-    List<String> wpilibDesktopJni() {
-        def debug = wpi.debugSimJNI ? "debug" : ""
-
-        return ["edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:${wpi.platforms.desktop}${debug}@zip".toString(),
-                "edu.wpi.first.hal:hal-cpp:${wpi.wpilibVersion}:${wpi.platforms.desktop}${debug}@zip".toString(),
-                "edu.wpi.first.wpiutil:wpiutil-cpp:${wpi.wpilibVersion}:${wpi.platforms.desktop}${debug}@zip".toString(),
-                "edu.wpi.first.ntcore:ntcore-cpp:${wpi.wpilibVersion}:${wpi.platforms.desktop}${debug}@zip".toString(),
-                "edu.wpi.first.cscore:cscore-cpp:${wpi.wpilibVersion}:${wpi.platforms.desktop}${debug}@zip".toString()]
+    List<String> wpilibEmbeddedJni(String platform) {
+        return wpilibEmbeddedJniInternal(false, platform)
     }
 
-    // TODO: Need Raspbian JNI Configuration!
-    List<String> wpilibRaspbianJni() {
-        return ["edu.wpi.first.thirdparty.frc2019.opencv:opencv-cpp:${wpi.opencvVersion}:${wpi.platforms.raspbian}@zip".toString(),
-                "edu.wpi.first.hal:hal-cpp:${wpi.wpilibVersion}:${wpi.platforms.raspbian}@zip".toString(),
-                "edu.wpi.first.wpiutil:wpiutil-cpp:${wpi.wpilibVersion}:${wpi.platforms.raspbian}@zip".toString(),
-                "edu.wpi.first.ntcore:ntcore-cpp:${wpi.wpilibVersion}:${wpi.platforms.raspbian}@zip".toString(),
-                "edu.wpi.first.cscore:cscore-cpp:${wpi.wpilibVersion}:${wpi.platforms.raspbian}@zip".toString()]
+    List<String> wpilibEmbeddedJniDebug(String platform) {
+        return wpilibEmbeddedJniInternal(true, platform);
+    }
+
+    List<String> wpilibEmbeddedJniInternal(boolean debug, String platform) {
+        def debugString = debug ? "debug" : ""
+
+        // The JNI jars are for embedding into an output jar
+        return ["edu.wpi.first.thirdparty.frc2019.opencv:opencv-jni:${wpi.opencvVersion}:${platform}${debugString}@jar".toString(),
+                "edu.wpi.first.hal:hal-jni:${wpi.wpilibVersion}:${platform}${debugString}@jar".toString(),
+                "edu.wpi.first.wpiutil:wpiutil-jni:${wpi.wpilibVersion}:${platform}${debugString}@jar".toString(),
+                "edu.wpi.first.ntcore:ntcore-jni:${wpi.wpilibVersion}:${platform}${debugString}@jar".toString(),
+                "edu.wpi.first.cscore:cscore-jni:${wpi.wpilibVersion}:${platform}${debugString}@jar".toString()]
     }
 
     class WPISimExtension {

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIVendorDepsExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIVendorDepsExtension.groovy
@@ -121,6 +121,14 @@ public class WPIVendorDepsExtension {
     }
 
     List<String> jni(String platform, String... ignore) {
+        return jniInternal(false, platform, ignore)
+    }
+
+    List<String> jniDebug(String platform, String... ignore) {
+        return jniInternal(true, platform, ignore)
+    }
+
+    List<String> jniInternal(boolean debug, String platform, String... ignore) {
         if (dependencies == null) return []
 
         def deps = [] as List<String>
@@ -133,10 +141,8 @@ public class WPIVendorDepsExtension {
                         throw new WPIDependenciesPlugin.MissingJniDependencyException(dep.name, platform, jni)
 
                     if (applies) {
-                        def debug = wpiExt.debugSimJNI ? "debug" : ""
-                        debug = platform.equals(NativePlatforms.roborio) ? "debug" : debug
-                        debug = platform.equals(NativePlatforms.raspbian) ? "" : debug
-                        deps.add("${jni.groupId}:${jni.artifactId}:${getVersion(jni.version, wpiExt)}:${platform}${debug}@${jni.isJar ? 'jar' : 'zip'}".toString())
+                        def debugString = debug ? "debug" : ""
+                        deps.add("${jni.groupId}:${jni.artifactId}:${getVersion(jni.version, wpiExt)}:${platform}${debugString}@${jni.isJar ? 'jar' : 'zip'}".toString())
                     }
                 }
             }


### PR DESCRIPTION
Make it more explicit so it matches the vendor code. Also will make it easier to add more platforms, as well as combined jars.

Also makes switching between debug and release in java possible.