### PR TITLE
Allow separate jars to be deployed for Java apps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     compile 'com.google.code.gson:gson:2.2.4'
     compile 'edu.wpi.first:gradle-cpp-vscode:0.9.4'
 
+    compile 'jaci.gradle:EmbeddedTools:2019.10.2'
     compile 'edu.wpi.first:native-utils:2020.1.0'
 
     compile 'com.jcraft:jsch:0.1.53'

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -24,6 +24,7 @@ deploy {
         frcJavaArtifact('frcJava') {
             targets << "roborio"
             // Debug can be overridden by command line, for use with VSCode
+            jarTask = jar
             debug = frc.getDebugOrDefault(false)
         }
         artifact('frcJavaClasspath', JavaClasspathConfigurationArtifact) {
@@ -41,6 +42,10 @@ deploy {
     }
 }
 
+repositories {
+    mavenCentral()
+}
+
 // Defining my dependencies. In this case, WPILib (+ friends), and vendor libraries.
 // Also defines JUnit 4.
 dependencies {
@@ -49,6 +54,7 @@ dependencies {
     nativeDesktopZip wpi.deps.wpilibJni(wpi.platforms.desktop)
 
     compile project(":lib")
+    compile "org.ejml:ejml-simple:0.38"
 
 
     compile wpi.deps.vendor.java()
@@ -61,9 +67,13 @@ dependencies {
 // Setting up my Jar File, adding the manifest so WPILib
 // knows where to look for our Robot Class.
 jar {
-    from { configurations.compileClasspath.findAll { it.isDirectory() } }
+    from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+
+    //from { configurations.compileClasspath.findAll { it.isDirectory() } }
     manifest edu.wpi.first.gradlerio.GradleRIOPlugin.javaManifest(ROBOT_MAIN_CLASS)
 }
+
+println jar.class
 
 wrapper {
     gradleVersion = '5.4.1'

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -23,6 +23,10 @@ deploy {
             // Debug can be overridden by command line, for use with VSCode
             debug = frc.getDebugOrDefault(false)
         }
+        frcJavaClasspathArtifact('frcJavaClasspath') {
+            targets << "roborio"
+            configuration = configurations.compileClasspath
+        }
         // Built in artifact to deploy arbitrary files to the roboRIO.
         fileTreeArtifact('frcStaticFileDeploy') {
             // The directory below is the local directory to deploy
@@ -49,11 +53,9 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
-// Setting up my Jar File. In this case, adding all libraries into the main jar ('fat jar')
-// in order to make them all available at runtime. Also adding the manifest so WPILib
+// Setting up my Jar File, adding the manifest so WPILib
 // knows where to look for our Robot Class.
 jar {
-    from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     manifest edu.wpi.first.gradlerio.GradleRIOPlugin.javaManifest(ROBOT_MAIN_CLASS)
 }
 

--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -1,3 +1,5 @@
+import edu.wpi.first.gradlerio.frc.*
+
 plugins {
     id "java"
     id "edu.wpi.first.GradleRIO" version "2020.0.0-alpha-3"
@@ -15,6 +17,7 @@ deploy {
             // You can use getTeamOrDefault(team) instead of getTeamNumber if you
             // want to store a team number in this file.
             team = frc.getTeamNumber()
+            addAddress('192.168.2.139')
         }
     }
     artifacts {
@@ -23,7 +26,7 @@ deploy {
             // Debug can be overridden by command line, for use with VSCode
             debug = frc.getDebugOrDefault(false)
         }
-        frcJavaClasspathArtifact('frcJavaClasspath') {
+        artifact('frcJavaClasspath', JavaClasspathConfigurationArtifact) {
             targets << "roborio"
             configuration = configurations.compileClasspath
         }
@@ -45,6 +48,8 @@ dependencies {
     nativeZip wpi.deps.wpilibJni(wpi.platforms.roborio)
     nativeDesktopZip wpi.deps.wpilibJni(wpi.platforms.desktop)
 
+    compile project(":lib")
+
 
     compile wpi.deps.vendor.java()
     nativeZip wpi.deps.vendor.jni(wpi.platforms.roborio)
@@ -56,6 +61,7 @@ dependencies {
 // Setting up my Jar File, adding the manifest so WPILib
 // knows where to look for our Robot Class.
 jar {
+    from { configurations.compileClasspath.findAll { it.isDirectory() } }
     manifest edu.wpi.first.gradlerio.GradleRIOPlugin.javaManifest(ROBOT_MAIN_CLASS)
 }
 

--- a/examples/java/lib/build.gradle
+++ b/examples/java/lib/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'java-library'
+}

--- a/examples/java/lib/src/main/java/MyClass.java
+++ b/examples/java/lib/src/main/java/MyClass.java
@@ -1,0 +1,3 @@
+public class MyClass {
+    
+}

--- a/examples/java/settings.gradle
+++ b/examples/java/settings.gradle
@@ -25,3 +25,5 @@ pluginManagement {
         }
     }
 }
+
+include 'lib'

--- a/examples/kotlin/build.gradle
+++ b/examples/kotlin/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 // Setting up my Jar File, adding the manifest so WPILib
 // knows where to look for our Robot Class.
 jar {
+    from { configurations.compileClasspath.findAll { it.isDirectory() } }
     manifest edu.wpi.first.gradlerio.GradleRIOPlugin.javaManifest(ROBOT_MAIN_CLASS)
 }
 

--- a/examples/kotlin/build.gradle
+++ b/examples/kotlin/build.gradle
@@ -23,6 +23,10 @@ deploy {
             // Debug can be overridden by command line, for use with VSCode
             debug = frc.getDebugOrDefault(false)
         }
+        frcJavaClasspathArtifact('frcJavaClasspath') {
+            targets << "roborio"
+            configuration = configurations.compileClasspath
+        }
         // Built in artifact to deploy arbitrary files to the roboRIO.
         fileTreeArtifact('frcStaticFileDeploy') {
             // The directory below is the local directory to deploy
@@ -53,11 +57,9 @@ dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib"
 }
 
-// Setting up my Jar File. In this case, adding all libraries into the main jar ('fat jar')
-// in order to make them all available at runtime. Also adding the manifest so WPILib
+// Setting up my Jar File, adding the manifest so WPILib
 // knows where to look for our Robot Class.
 jar {
-    from { configurations.compileClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     manifest edu.wpi.first.gradlerio.GradleRIOPlugin.javaManifest(ROBOT_MAIN_CLASS)
 }
 

--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCJavaArtifact.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCJavaArtifact.groovy
@@ -38,7 +38,7 @@ class FRCJavaArtifact extends JavaArtifact {
     String debugFlags = "-XX:+UsePerfData -agentlib:jdwp=transport=dt_socket,address=0.0.0.0:${debugPort},server=y,suspend=y"
 
     def robotCommand = {
-        "/usr/local/frc/JRE/bin/java -Djava.library.path=${FRCPlugin.LIB_DEPLOY_DIR} -Djava.lang.invoke.stringConcat=BC_SB –XX:+UseConcMarkSweepGC ${jvmArgs.join(" ")} ${debug ? debugFlags : ""} -jar \"<<BINARY>>\" ${arguments.join(" ")}"
+        "/usr/local/frc/JRE/bin/java -Djava.library.path=${FRCPlugin.LIB_DEPLOY_DIR} -Djava.lang.invoke.stringConcat=BC_SB –XX:+UseConcMarkSweepGC ${jvmArgs.join(" ")} ${debug ? debugFlags : ""} -cp ${FRCPlugin.LIB_DEPLOY_DIR};/home/lvuser -jar \"<<BINARY>>\" ${arguments.join(" ")}"
     }
 
     @Override

--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCPlugin.groovy
@@ -63,7 +63,13 @@ class FRCPlugin implements Plugin<Project> {
         def targetExtension = deployExtension.targets
 
         artifactExtensionAware.extensions.add('frcJavaArtifact', { String name, Closure closure->
-            return artifactExtension.artifact(name, FRCJavaArtifact, new ActionWrapper(closure))
+            FRCJavaArtifact jArtifact = (FRCJavaArtifact)artifactExtension.artifact(name, FRCJavaArtifact, new ActionWrapper(closure))
+            JavaClasspathConfigurationArtifact confArtifact = (JavaClasspathConfigurationArtifact)artifactExtension.artifact(name + 'Classpath', JavaClasspathConfigurationArtifact, new ActionWrapper({
+                targets.addAll(jArtifact.targets)
+                configurations = jArtifact.dependencyConfigurations
+            }))
+            jArtifact.classpathArtifact = confArtifact
+            return jArtifact
         })
 
         artifactExtensionAware.extensions.add('frcNativeArtifact', { String name, Closure closure->

--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/JavaClasspathConfigurationArtifact.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/JavaClasspathConfigurationArtifact.groovy
@@ -1,0 +1,70 @@
+package edu.wpi.first.gradlerio.frc
+
+import groovy.transform.CompileStatic
+import javax.inject.Inject
+import jaci.gradle.deploy.artifact.FileCollectionArtifact
+import jaci.gradle.deploy.context.DeployContext
+import jaci.gradle.ActionWrapper
+import org.gradle.api.Action
+import jaci.gradle.Resolver
+import jaci.gradle.deploy.cache.CacheMethod
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.util.PatternFilterable
+import jaci.gradle.deploy.artifact.AbstractArtifact
+import org.gradle.api.provider.Property
+import jaci.gradle.PathUtils
+
+import java.util.concurrent.Callable
+
+@CompileStatic
+class JavaClasspathConfigurationArtifact extends AbstractArtifact implements Callable<FileCollection> {
+
+    Configuration configuration
+    final Property<FileCollection> files
+    private FileCollection resolvedFiles
+
+    @Inject
+    JavaClasspathConfigurationArtifact(String name, Project project) {
+        super(name, project)
+        files = project.objects.property(FileCollection)
+        directory = PathUtils.combine(FRCPlugin.LIB_DEPLOY_DIR, 'java')
+        onlyIf = { DeployContext ctx ->
+            files.isPresent() && !files.get().empty && !files.get().files.empty
+        }
+
+        files.set(project.files(this as Callable<FileCollection>))
+    }
+
+    Object cache = "md5sum"
+    Resolver<CacheMethod> cacheResolver
+
+    @Override
+    void deploy(DeployContext context) {
+        if (files.isPresent()) {
+            Map<String, File> filesToWrite = [:]
+            files.get().files.each {
+                filesToWrite.put(it.name.replaceFirst(~/\.[^\.] $/, ''), it)
+            }
+            context.put(filesToWrite, cacheResolver?.resolve(cache))
+        } else {
+            context.logger?.log("No file(s) provided for ${toString()}")
+        }
+    }
+
+    List<String> getFileNames() {
+        return files.get().files.collect { it.name.replaceFirst(~/\.[^\.] $/, '') }
+    }
+
+    @Override
+    FileCollection call() {
+        if (resolvedFiles != null) {
+            return resolvedFiles
+        }
+        def conf = configuration.resolvedConfiguration
+        resolvedFiles = project.files(conf.files)
+
+        return resolvedFiles
+    }
+}

--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/JavaClasspathConfigurationArtifact.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/JavaClasspathConfigurationArtifact.groovy
@@ -15,6 +15,7 @@ import org.gradle.api.tasks.util.PatternFilterable
 import jaci.gradle.deploy.artifact.AbstractArtifact
 import jaci.gradle.deploy.artifact.CacheableArtifact
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.ListProperty
 import jaci.gradle.PathUtils
 
 import java.util.concurrent.Callable
@@ -22,7 +23,7 @@ import java.util.concurrent.Callable
 @CompileStatic
 class JavaClasspathConfigurationArtifact extends AbstractArtifact implements Callable<FileCollection>, CacheableArtifact {
 
-    Configuration configuration
+    ListProperty<Configuration> configurations
     final Property<FileCollection> files
     private FileCollection resolvedFiles
 
@@ -65,10 +66,13 @@ class JavaClasspathConfigurationArtifact extends AbstractArtifact implements Cal
         if (resolvedFiles != null) {
             return resolvedFiles
         }
-        // Only resolve files, not classpath folders
-        def conf = configuration.resolvedConfiguration.files.findAll { !it.isDirectory() }
-        resolvedFiles = project.files(conf)
-
+        resolvedFiles = []
+        configurations.get.each() {
+            // Only resolve files, not classpath folders
+            def conf = configuration.resolvedConfiguration.files.findAll { !it.isDirectory() }
+            resolvedFiles += project.files(conf)
+        }
+        
         return resolvedFiles
     }
 }

--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/RoboRIO.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/RoboRIO.groovy
@@ -26,7 +26,7 @@ class RoboRIO extends FRCCompatibleTarget {
         this.maxChannels = 4
 
         this.onlyIf = { DeployContext ctx ->
-            verifyOnlyIf(ctx)
+            return verifyOnlyIf(ctx)
         }
 
         // Make a copy of valid image versions so user defined cannot modify the global array


### PR DESCRIPTION
WIP, and needs to be tested

For this to work, every deployed classpath artifact needs to be put in its own folder. This is because Java doesn't allow naming dependencies, and maven gives different versions of the same artifact different names, with the version included. If we were to just deploy all dependencies to a single folder, if an update were to occur, multiple versions of the same artifact would be deployed with separate names, and the behavior is undefined which one would be used. 