### PR TITLE
Update to 2020 image being used

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIExtension.groovy
@@ -17,9 +17,10 @@ import javax.inject.Inject
 class WPIExtension {
     // WPILib (first.wpi.edu/FRC/roborio/maven) libs
     String wpilibVersion = "2019.+"
-    String niLibrariesVersion = "2019.12.2"
+    String niLibrariesVersion = "2020.2.2"
     String opencvVersion = "3.4.7-1"
-    static final String[] validImageVersions = ['2019_v14']
+    String imguiVersion = "1.72b-1"
+    static final String[] validImageVersions = ['2020_v2']
 
     String wpilibYear = '2020'
 
@@ -139,6 +140,7 @@ class WPIExtension {
                 "opencvVersion"        : new Tuple("OpenCV", opencvVersion, "opencv"),
                 "wpilibYear"           : new Tuple("WPILib Year", wpilibYear, "wpilibYear"),
                 "googleTestVersion"    : new Tuple("Google Test", googleTestVersion, "googleTest"),
+                "imguiVersion"         : new Tuple("ImGUI", imguiVersion, "imgui"),
 
                 "smartDashboardVersion": new Tuple("SmartDashboard", smartDashboardVersion, "smartdashboard"),
                 "shuffleboardVersion"  : new Tuple("Shuffleboard", shuffleboardVersion, "shuffleboard"),

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIPlugin.groovy
@@ -59,6 +59,7 @@ class WPIPlugin implements Plugin<Project> {
                     it.niLibVersion = wpiExt.niLibrariesVersion
                     it.opencvVersion = wpiExt.opencvVersion
                     it.googleTestVersion = wpiExt.googleTestVersion
+                    it.imguiVersion = wpiExt.imguiVersion
                 }
             }
 

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPINativeJsonDepRules.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPINativeJsonDepRules.groovy
@@ -32,7 +32,7 @@ class WPINativeJsonDepRules extends RuleSource {
                 String linkSuff     = cpp.sharedLibrary ? '' : 'static'
                 String name = dep.uuid + cpp.libName
                 String mavenbase = "${cpp.groupId}:${cpp.artifactId}:${WPIVendorDepsExtension.getVersion(cpp.version, wpi)}"
-                String config = cpp.configuration ?: "native_${dep.uuid}"
+                String config = cpp.configuration ?: "native_${dep.uuid}_${cpp.groupId}${cpp.artifactId}"
                 List<String> allPlatforms = platformContainer.collect { Platform p -> p.name }
 
                 // Note: because of a discrepancy between the target platforms of the headers, sources


### PR DESCRIPTION
You won't be able to deploy to a stock 2020 image, as its missing a dependent library.