### PR TITLE
Add missing dependencies between zip and patch examples

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ examplesFolder.eachFile { File file ->
             }
 
             zipExamples.dependsOn it
+            it.dependsOn PatchExamples
         }
     }
 }


### PR DESCRIPTION
Hi

This commit adds missing dependencies between zip-related tasks and patch examples.

As it is shown above, `PatchExamples` can be executed after zip-related tasks,
leaving archives in an inconsistent state.

```
> Task :zipExamplejava
Caching disabled for task ':zipExamplejava' because:
  Build cache is disabled
Task ':zipExamplejava' is not up-to-date because:
  Input property 'rootSpec$1$1' file /root/GradleRIO/examples/java/build.gradle has changed.
:zipExamplejava (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.019 secs.
:PatchExamples (Thread[Execution worker for ':' Thread 2,5,main]) started.

> Task :PatchExamples
Caching disabled for task ':PatchExamples' because:
  Build cache is disabled
Task ':PatchExamples' is not up-to-date because:
  Task has not declared any outputs despite executing actions.
:PatchExamples (Thread[Execution worker for ':' Thread 2,5,main]) completed. Took 0.004 secs.
``` 