### PR TITLE
Add KDevelop editor plugin

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/GradleRIOPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/GradleRIOPlugin.groovy
@@ -5,6 +5,7 @@ import edu.wpi.first.gradlerio.frc.FRCPlugin
 import edu.wpi.first.gradlerio.frc.RoboRIO
 import edu.wpi.first.gradlerio.ide.ClionPlugin
 import edu.wpi.first.gradlerio.ide.IDEPlugin
+import edu.wpi.first.gradlerio.ide.KDevelopPlugin
 import edu.wpi.first.gradlerio.test.TestPlugin
 import edu.wpi.first.gradlerio.wpi.WPIPlugin
 import groovy.transform.CompileStatic
@@ -60,6 +61,7 @@ class GradleRIOPlugin implements Plugin<Project> {
         project.pluginManager.apply(ClionPlugin)
         project.pluginManager.apply(IDEPlugin)
         project.pluginManager.apply(TestPlugin)
+        project.pluginManager.apply(KDevelopPlugin)
 
         project.extensions.add('projectWrapper', new ProjectWrapper(project))
 

--- a/src/main/groovy/edu/wpi/first/gradlerio/ide/GenerateKDevelopTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/ide/GenerateKDevelopTask.groovy
@@ -1,0 +1,83 @@
+package edu.wpi.first.gradlerio.ide
+
+import groovy.transform.CompileStatic
+import org.gradle.api.DefaultTask
+import org.gradle.api.Project
+import org.gradle.api.Plugin
+import org.gradle.api.tasks.TaskAction
+import org.gradle.nativeplatform.NativeDependencySet
+import org.gradle.nativeplatform.NativeExecutableBinarySpec
+
+
+import java.nio.file.Paths
+
+@CompileStatic
+class GenerateKDevelopTask extends DefaultTask {
+    @TaskAction
+    void generate() {
+        def projectFile = new FileWriter(project.file("${project.name}.kdev4"))
+        projectFile.write("""\
+[Project]
+Manager=KDevCustomBuildSystem
+""")
+        projectFile.write("Name=${project.name}")
+        projectFile.close()
+
+        def headerPaths = []
+        def ext = project.extensions.getByType(EditorConfigurationExtension)
+        ext._binaries.each { NativeExecutableBinarySpec bin ->
+            bin.libs.each { NativeDependencySet ds ->
+                headerPaths += ds.getIncludeRoots()
+            }
+        }
+        headerPaths = headerPaths.unique()
+
+        new File(".kdev4").mkdir()
+        def buildSystemFile = new FileWriter(project.file(".kdev4/${project.name}.kdev4"))
+        buildSystemFile.write("""\
+[CustomBuildSystem]
+CurrentConfiguration=BuildConfig0
+
+[CustomBuildSystem][BuildConfig0]
+BuildDir=
+Title=FRC GradleRIO
+
+[CustomBuildSystem][BuildConfig0][ToolBuild]
+Arguments=build
+Enabled=true
+Executable=file:///${project.projectDir}/gradlew
+Type=0
+
+[CustomBuildSystem][BuildConfig0][ToolClean]
+Arguments=clean
+Enabled=true
+Executable=file:///${project.projectDir}/gradlew
+Type=3
+
+[CustomBuildSystem][BuildConfig0][ToolInstall]
+Arguments=deploy
+Enabled=true
+Executable=file:///${project.projectDir}/gradlew
+Type=2
+
+[CustomDefinesAndIncludes][ProjectPath0][Includes]
+""")
+        headerPaths.eachWithIndex {dir, index ->
+            buildSystemFile.write("${index + 1}=${dir}\n")
+        }
+        buildSystemFile.close()
+    }
+}
+
+class KDevelopPlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+        project.pluginManager.apply(ComponentModelBasePlugin)
+        project.extensions.create('KDevelop', EditorConfigurationExtension)
+
+        project.tasks.register('KDevelop', GenerateKDevelopTask) { GenerateKDevelopTask task ->
+            task.group = "GradleRIO"
+            task.description = "Generate KDevelop4 Build Files."
+        }
+    }
+}

--- a/src/main/groovy/edu/wpi/first/gradlerio/ide/GenerateKDevelopTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/ide/GenerateKDevelopTask.groovy
@@ -2,12 +2,9 @@ package edu.wpi.first.gradlerio.ide
 
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
-import org.gradle.api.Project
-import org.gradle.api.Plugin
 import org.gradle.api.tasks.TaskAction
 import org.gradle.nativeplatform.NativeDependencySet
 import org.gradle.nativeplatform.NativeExecutableBinarySpec
-
 
 import java.nio.file.Paths
 
@@ -66,18 +63,5 @@ Type=2
             buildSystemFile.write("${index + 1}=${dir}\n")
         }
         buildSystemFile.close()
-    }
-}
-
-class KDevelopPlugin implements Plugin<Project> {
-    @Override
-    void apply(Project project) {
-        project.pluginManager.apply(ComponentModelBasePlugin)
-        project.extensions.create('KDevelop', EditorConfigurationExtension)
-
-        project.tasks.register('KDevelop', GenerateKDevelopTask) { GenerateKDevelopTask task ->
-            task.group = "GradleRIO"
-            task.description = "Generate KDevelop4 Build Files."
-        }
     }
 }

--- a/src/main/groovy/edu/wpi/first/gradlerio/ide/KDevelopPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/ide/KDevelopPlugin.groovy
@@ -1,0 +1,28 @@
+package edu.wpi.first.gradlerio.ide
+
+import org.gradle.api.Project
+import org.gradle.api.Plugin
+import org.gradle.api.tasks.Delete
+import org.gradle.language.base.plugins.ComponentModelBasePlugin
+
+class KDevelopPlugin implements Plugin<Project> {
+    @Override
+    void apply(Project project) {
+        project.pluginManager.apply(ComponentModelBasePlugin)
+        project.extensions.create('kdevelop', EditorConfigurationExtension)
+
+        project.tasks.register('kdevelop', GenerateKDevelopTask) { GenerateKDevelopTask task ->
+            task.group = "GradleRIO"
+            task.description = "Generate KDevelop4 IDE Files."
+        }
+
+        project.tasks.register('cleanKDevelop', Delete) { Delete task ->
+            task.group = "GradleRIO"
+            task.description = "Clean KDevelop4 IDE Files."
+            [".kdev4", "${project.name}.kdev4"].each {String file ->
+                def f = new File(file)
+                if (f.exists()) task.delete(f)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Autogenerates KDevelop 4 files with `./gradlew kdevelop`.
This also supports cleaning them with `./gradlew cleanKDevelop`.

KDevelop4 does not support relative paths in the configuration files so they have to be absolute.