### PR TITLE
Fix macOS Catalina unit test/simulateJava issue

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/test/JavaTestPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/JavaTestPlugin.groovy
@@ -46,9 +46,16 @@ class JavaTestPlugin implements Plugin<Project> {
 
                 def ldpath = jniExtractionDir(project).absolutePath
 
-                if (OperatingSystem.current().isUnix()) {
+                // must check for isMacOsX first, because isUnix() returns true on a mac
+                if (OperatingSystem.current().isMacOsX()) {
+                    if (OperatingSystem.current().toString().contains("10.15")) {
+                        env["DYLD_LIBRARY_PATH"] = ldpath // On macoOS Catalina, DYLD_FALLBACK_LIBRARY_PATH doesn't work
+                    } else {
+                        env["DYLD_FALLBACK_LIBRARY_PATH"] = ldpath // On macOS before Catalina, it isn't 'safe' to override the non-fallback version.
+                                                                   // Gatekeeper will prevent loading dynamic libraries from relative
+                    }
+                } else if (OperatingSystem.current().isUnix()) {
                     env["LD_LIBRARY_PATH"] = ldpath
-                    env["DYLD_FALLBACK_LIBRARY_PATH"] = ldpath // On Mac it isn't 'safe' to override the non-fallback version.
                 } else if (OperatingSystem.current().isWindows()) {
                     env["PATH"] = ldpath + TestPlugin.envDelimiter() + System.getenv("PATH")
                 }


### PR DESCRIPTION
https://github.com/wpilibsuite/GradleRIO/issues/413

on macOS Catalina, running unit tests and launching the simulator fail with an error about being unable to load a native library.

This update fixes the environment to use `DYLD_LIBRARY_PATH` for macOS 10.15.

If someone has a suggestion on making this 10.15 or greater, let me know. I didn't want to complicate the code with version parsing. Once macOS Catalina is the default supported macOS, the code should be switched to use `DYLD_LIBRARY_PATH` for mac.