### PR TITLE
Add a vendordep gradle task

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Open `WPILib: Manage Vendor Libraries`, `Install new libraries (online)`, and pa
 ### Without Visual Studio Code
 Create a folder `vendordeps` in your project directory if it doesn't already exist.
 Download the JSON file from the vendor-provided URL, and save it to the `vendordeps` folder.
+This can be done by running `./gradlew vendordep --url=<vendor url here>` in a project. 
 
 ## Commands
 Windows Users: It is recommended to use Powershell instead of CMD. You can switch to powershell with `powershell`

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     api 'edu.wpi.first:gradle-cpp-vscode:0.12.0'
 
     api 'edu.wpi.first:native-utils:2020.7.2'
-    
+
     api 'de.undercouch:gradle-download-task:4.1.1'
 
     testImplementation('org.spockframework:spock-core:1.2-groovy-2.5') {

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ dependencies {
     api 'edu.wpi.first:gradle-cpp-vscode:0.12.0'
 
     api 'edu.wpi.first:native-utils:2020.7.2'
+    
+    api'de.undercouch:gradle-download-task:4.0.4'
 
     testImplementation('org.spockframework:spock-core:1.2-groovy-2.5') {
         exclude group: 'org.codehaus.groovy'

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ dependencies {
 
     api 'edu.wpi.first:native-utils:2020.7.2'
     
-    api'de.undercouch:gradle-download-task:4.0.4'
+    api 'de.undercouch:gradle-download-task:4.1.1'
 
     testImplementation('org.spockframework:spock-core:1.2-groovy-2.5') {
         exclude group: 'org.codehaus.groovy'

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
@@ -25,12 +25,12 @@ class VendorDepTask extends DefaultTask{
     private static String findFileName(String url) {
         if (url == null) {
             throw new IllegalArgumentException(
-                    "No vendor JSON URL was entered. Try the following:\n\tgradlew vendordep --url <insert_url_here>")
+                    "No vendor JSON URL was entered. Try the following:\n\tgradlew vendordep --url=<insert_url_here>")
         }
         int lastUrlSeparator = url.lastIndexOf('/')
         if (lastUrlSeparator == -1) {
             throw new IllegalArgumentException(
-                    "No vendor JSON URL was entered. Try the following:\n\tgradlew vendordep --url <insert_url_here>")
+                    "No vendor JSON URL was entered. Try the following:\n\tgradlew vendordep --url=<insert_url_here>")
         }
         String name = url.substring(lastUrlSeparator + 1)
         return "vendordeps/${name}"

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
@@ -1,0 +1,41 @@
+package edu.wpi.first.gradlerio.wpi.dependencies
+
+import org.gradle.api.tasks.Exec
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
+
+/**
+ * A task type for downloading vendordep JSON files from the vendor URL.
+ */
+class VendorDepTask extends Exec{
+    private String url
+//    private String file
+
+    @Option(option = "url", description = "The vendordep JSON URL.")
+    void setURL(String url) {
+        this.url = url
+    }
+
+    /**
+     * Find the name of the JSON file.
+     * @param url the vendor JSON URL
+     * @return the name of the JSON file, with the `.json` suffix
+     */
+    private static String findFileName(String url) {
+        int lastUrlSeparator = url.lastIndexOf('/')
+        if(lastUrlSeparator == -1) {
+            throw new IllegalArgumentException("No vendor JSON URL was entered.")
+        }
+        String name = url.substring(lastUrlSeparator + 1)
+        return "vendordeps/${name}"
+    }
+
+    /**
+     * Installs the JSON file
+     */
+    @TaskAction
+    def install() {
+        commandLine 'curl', '-o', findFileName(url), url
+    }
+
+}

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
@@ -1,13 +1,15 @@
 package edu.wpi.first.gradlerio.wpi.dependencies
 
-import de.undercouch.gradle.tasks.download.Download
+import de.undercouch.gradle.tasks.download.DownloadAction
+import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 /**
  * A task type for downloading vendordep JSON files from the vendor URL.
  */
-class VendorDepTask extends Download{
+class VendorDepTask extends DefaultTask{
     private String url
+    private DownloadAction da = new DownloadAction(getProject())
 
     @Option(option = "url", description = "The vendordep JSON URL.")
     void setURL(String url) {
@@ -20,6 +22,9 @@ class VendorDepTask extends Download{
      * @return the name of the JSON file, with the `.json` suffix
      */
     private static String findFileName(String url) {
+        if(url == null) {
+            throw new IllegalArgumentException("No vendor JSON URL was entered.")
+        }
         int lastUrlSeparator = url.lastIndexOf('/')
         if(lastUrlSeparator == -1) {
             throw new IllegalArgumentException("No vendor JSON URL was entered.")
@@ -32,11 +37,9 @@ class VendorDepTask extends Download{
      * Installs the JSON file
      */
     @TaskAction
-    def install() {
-        download {
-            src url
-            dest findFileName(url)
-            overwrite true
-        }
+    public void install() throws IOException {
+        da.src(url)
+        da.dest(findFileName(url))
+        da.execute()
     }
 }

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
@@ -1,13 +1,12 @@
 package edu.wpi.first.gradlerio.wpi.dependencies
 
-import org.gradle.api.tasks.Exec
+import de.undercouch.gradle.tasks.download.Download
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
-
 /**
  * A task type for downloading vendordep JSON files from the vendor URL.
  */
-class VendorDepTask extends Exec{
+class VendorDepTask extends Download{
     private String url
 //    private String file
 
@@ -35,7 +34,11 @@ class VendorDepTask extends Exec{
      */
     @TaskAction
     def install() {
-        commandLine 'curl', '-o', findFileName(url), url
+        download {
+            src url
+            dest findFileName(url)
+            overwrite true
+        }
     }
 
 }

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
@@ -4,6 +4,7 @@ import de.undercouch.gradle.tasks.download.DownloadAction
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
+
 /**
  * A task type for downloading vendordep JSON files from the vendor URL.
  */
@@ -22,12 +23,14 @@ class VendorDepTask extends DefaultTask{
      * @return the name of the JSON file, with the `.json` suffix
      */
     private static String findFileName(String url) {
-        if(url == null) {
-            throw new IllegalArgumentException("No vendor JSON URL was entered.")
+        if (url == null) {
+            throw new IllegalArgumentException(
+                    "No vendor JSON URL was entered. Try the following:\n\tgradlew vendordep --url <insert_url_here>")
         }
         int lastUrlSeparator = url.lastIndexOf('/')
-        if(lastUrlSeparator == -1) {
-            throw new IllegalArgumentException("No vendor JSON URL was entered.")
+        if (lastUrlSeparator == -1) {
+            throw new IllegalArgumentException(
+                    "No vendor JSON URL was entered. Try the following:\n\tgradlew vendordep --url <insert_url_here>")
         }
         String name = url.substring(lastUrlSeparator + 1)
         return "vendordeps/${name}"
@@ -37,7 +40,7 @@ class VendorDepTask extends DefaultTask{
      * Installs the JSON file
      */
     @TaskAction
-    public void install() throws IOException {
+    void install() throws IOException {
         da.src(url)
         da.dest(findFileName(url))
         da.execute()

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
@@ -8,7 +8,6 @@ import org.gradle.api.tasks.options.Option
  */
 class VendorDepTask extends Download{
     private String url
-//    private String file
 
     @Option(option = "url", description = "The vendordep JSON URL.")
     void setURL(String url) {
@@ -40,5 +39,4 @@ class VendorDepTask extends Download{
             overwrite true
         }
     }
-
 }

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.groovy
@@ -16,6 +16,7 @@ import java.nio.file.StandardCopyOption
 class VendorDepTask extends DefaultTask {
     private String url
     private DownloadAction downloadAction = new DownloadAction(getProject())
+    private wpiExt = project.getExtensions().getByType(WPIExtension)
 
     @Option(option = "url", description = "The vendordep JSON URL or path")
     void setURL(String url) {
@@ -71,7 +72,7 @@ class VendorDepTask extends DefaultTask {
      * @param dest the destination file
      */
     private void copyLocal(String filename, Path dest) {
-        Path localCache = Path.of(WPIExtension.getFrcHome()).resolve(WPIExtension.getFrcYear()).resolve("vendordeps")
+        Path localCache = Path.of(wpiExt.getFrcHome()).resolve(wpiExt.getFrcYear()).resolve("vendordeps")
         File localFolder = localCache.toFile()
         if (localFolder.isDirectory()) {
             List<File> matches = localFolder.listFiles(new FilenameFilter() {

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIDependenciesPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIDependenciesPlugin.groovy
@@ -48,10 +48,10 @@ class WPIDependenciesPlugin implements Plugin<Project> {
             }
         } as Action<Task>)
 
-        project.tasks.register("vendordep", VendorDepTask, { VendorDepTask task ->
+        project.tasks.register("vendordep", VendorDepTask) { VendorDepTask task ->
             task.group = "GradleRIO"
             task.description = "Install vendordep JSON file from URL"
-        })
+        }
 
         project.tasks.withType(Jar) { Jar jarTask ->
             jarTask.dependsOn(lazyPreempt)

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIDependenciesPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIDependenciesPlugin.groovy
@@ -50,7 +50,7 @@ class WPIDependenciesPlugin implements Plugin<Project> {
 
         project.tasks.register("vendordep", VendorDepTask) { VendorDepTask task ->
             task.group = "GradleRIO"
-            task.description = "Install vendordep JSON file from URL"
+            task.description = "Install vendordep JSON file from URL or local wpilib folder"
         }
 
         project.tasks.withType(Jar) { Jar jarTask ->

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIDependenciesPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIDependenciesPlugin.groovy
@@ -48,6 +48,11 @@ class WPIDependenciesPlugin implements Plugin<Project> {
             }
         } as Action<Task>)
 
+        project.tasks.register("vendordep", VendorDepTask, { VendorDepTask task ->
+            task.group = "GradleRIO"
+            task.description = "Install vendordep JSON file from URL"
+        } as Action<VendorDepTask>)
+
         project.tasks.withType(Jar) { Jar jarTask ->
             jarTask.dependsOn(lazyPreempt)
         }

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIDependenciesPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIDependenciesPlugin.groovy
@@ -51,7 +51,7 @@ class WPIDependenciesPlugin implements Plugin<Project> {
         project.tasks.register("vendordep", VendorDepTask, { VendorDepTask task ->
             task.group = "GradleRIO"
             task.description = "Install vendordep JSON file from URL"
-        } as Action<VendorDepTask>)
+        })
 
         project.tasks.withType(Jar) { Jar jarTask ->
             jarTask.dependsOn(lazyPreempt)


### PR DESCRIPTION
Fixes #417 
The original commit uses curl, the second uses the [gradle-download plugin](https://github.com/michel-kraemer/gradle-download-task). 