### PR TITLE
Revert "use methodhandle-based generator for string concatenation

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCJavaArtifact.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/frc/FRCJavaArtifact.groovy
@@ -38,7 +38,7 @@ class FRCJavaArtifact extends JavaArtifact {
     String debugFlags = "-XX:+UsePerfData -agentlib:jdwp=transport=dt_socket,address=0.0.0.0:${debugPort},server=y,suspend=y"
 
     def robotCommand = {
-        "/usr/local/frc/JRE/bin/java -XX:+UseConcMarkSweepGC -Djava.library.path=${FRCPlugin.LIB_DEPLOY_DIR} -Djava.lang.invoke.stringConcat=MH_INLINE_SIZED_EXACT ${jvmArgs.join(" ")} ${debug ? debugFlags : ""} -jar \"<<BINARY>>\" ${arguments.join(" ")}"
+        "/usr/local/frc/JRE/bin/java -XX:+UseConcMarkSweepGC -Djava.library.path=${FRCPlugin.LIB_DEPLOY_DIR} -Djava.lang.invoke.stringConcat=BC_SB ${jvmArgs.join(" ")} ${debug ? debugFlags : ""} -jar \"<<BINARY>>\" ${arguments.join(" ")}"
     }
 
     @Override


### PR DESCRIPTION
This reverts commit 218e8c791eb40b1229651dbbe2250b20cea4ebf5.

This caused a long slowdown for first string concatenation using the code here:
https://www.chiefdelphi.com/t/improbable-java-slow-down-in-combining-doubles-and-strings/350331
It is ~40ms with BC_SB and ~560ms with methodhandle "MH_INLINE_SIZED_EXACT"