### PR TITLE
Fix simulateJava behaviour when filepath has spaces

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/ExternalLaunchTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/ExternalLaunchTask.groovy
@@ -70,7 +70,8 @@ class ExternalLaunchTask extends DefaultTask {
             File stdoutFile = new File(project.buildDir, "stdout/${name}.log")
             ProcessBuilder builder
             if (OperatingSystem.current().isWindows()) {
-                builder = new ProcessBuilder("cmd", "/c", "start", file.absolutePath)
+                builder = new ProcessBuilder("cmd", "/c", "start",
+                        "\"GradleRIO Simulation - ${project.name}\"", "\"${file.absolutePath}\"")
             } else {
                 builder = new ProcessBuilder(file.absolutePath)
                 stdoutFile.parentFile.mkdirs()


### PR DESCRIPTION
Fixes #419 

### The Problem
Turns out that the problem was with the format the `start` command parses its parameters ([source](https://ss64.com/nt/start.html)):
```cmd
START "title" [/D path] [options] "command" [parameters]
```
In the current/old code, the absolute filepath to the script is parsed as the command, but windows filepath resolving gets messed up with spaces. If we quote the filepath to go around the spacing issue, `start` parses it as the title and nothing is executed. 
#### Fix
In the new code, we give `start` a title so the filepath is correctly identified as the command, and quote the filepath so windows resolves the path correctly.

### Testing
I checked Java simulations (both with spaces and without), everything succeeded.
Can someone please check on MacOS/Linux to see if UNIX path resolving works with space-containing filepaths, and the `simulate***` tasks work?
Can someone also check C++/JNI simulations on any OS?