### PR TITLE
Add support for custom env vars in sim

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/ExternalLaunchTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/ExternalLaunchTask.groovy
@@ -36,6 +36,13 @@ class ExternalLaunchTask extends DefaultTask {
                 fileContent += "export ${entry.key}=${entry.value}\n"
             }
         }
+        customVars.each { Map.Entry<String, String> entry ->
+            if (OperatingSystem.current().isWindows()) {
+                fileContent += "set ${entry.key}=${entry.value}\n"
+            } else {
+                fileContent += "export ${entry.key}=${entry.value}\n"
+            }
+        }
 
         if (workingDir != null) {
             workingDir.mkdirs()
@@ -102,5 +109,10 @@ class ExternalLaunchTask extends DefaultTask {
         } else {
             return -1;
         }
+    }
+
+    private Map<String, String> customVars = [:]
+    void envVar(String name, String value) {
+        customVars[name] = value
     }
 }


### PR DESCRIPTION
Resolves #465 

- Java works well:
```groovy
simulateJava {
  envVar "myvariable", "value"
}
```

- C++ works as well, but a bit verbose/annoying:
```groovy
tasks.withType(edu.wpi.first.gradlerio.test.NativeSimulationTask.class) {
  envVar "myvariable", "value"
}
```

I will experiment a bit more to make C++ cleaner.
Thoughts?