### PR TITLE
Support setting sim env vars for VS Code

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/ExternalLaunchTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/ExternalLaunchTask.groovy
@@ -3,6 +3,7 @@ package edu.wpi.first.gradlerio
 import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
@@ -12,8 +13,8 @@ import edu.wpi.first.gradlerio.wpi.simulation.SimulationExtension
 @CompileStatic
 class ExternalLaunchTask extends DefaultTask {
 
-    @Internal
-    def environment = [:] as Map<String, String>
+    @Input
+    Map<String, String> environment = [:]
     @Internal
     boolean scriptOnly = false
     @Internal

--- a/src/main/groovy/edu/wpi/first/gradlerio/ExternalLaunchTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/ExternalLaunchTask.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.internal.jvm.Jvm
 import org.gradle.internal.os.OperatingSystem
 import org.gradle.process.ExecSpec
+import edu.wpi.first.gradlerio.wpi.simulation.SimulationExtension
 
 @CompileStatic
 class ExternalLaunchTask extends DefaultTask {
@@ -23,6 +24,8 @@ class ExternalLaunchTask extends DefaultTask {
     }
 
     Process launch(List<String> cmd) {
+        SimulationExtension simExtension = project.extensions.getByType(SimulationExtension)
+
         String fileContent = ""
         if (OperatingSystem.current().isWindows()) {
             fileContent += "@echo off\nsetlocal\n"
@@ -36,7 +39,7 @@ class ExternalLaunchTask extends DefaultTask {
                 fileContent += "export ${entry.key}=${entry.value}\n"
             }
         }
-        customVars.each { Map.Entry<String, String> entry ->
+        simExtension.environment.each { Map.Entry<String, String> entry ->
             if (OperatingSystem.current().isWindows()) {
                 fileContent += "set ${entry.key}=${entry.value}\n"
             } else {
@@ -109,10 +112,5 @@ class ExternalLaunchTask extends DefaultTask {
         } else {
             return -1;
         }
-    }
-
-    private Map<String, String> customVars = [:]
-    void envVar(String name, String value) {
-        customVars[name] = value
     }
 }

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/JavaExternalSimulationTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/JavaExternalSimulationTask.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.jvm.tasks.Jar
+import edu.wpi.first.gradlerio.wpi.simulation.SimulationExtension
 
 @CompileStatic
 class JavaExternalSimulationTask extends ExternalSimulationTask {
@@ -17,6 +18,7 @@ class JavaExternalSimulationTask extends ExternalSimulationTask {
     @TaskAction
     void create() {
         def cfgs = []
+        SimulationExtension simExtension = project.extensions.getByType(SimulationExtension)
         def extensions = TestPlugin.getHALExtensions(project)
         for (Jar jar : taskDependencies.getDependencies(this).findAll { it instanceof Jar } as Set<Jar>) {
             def manifestAttributes = jar.manifest.attributes
@@ -33,6 +35,7 @@ class JavaExternalSimulationTask extends ExternalSimulationTask {
             cfg['name'] = "${jar.baseName} (in project ${project.name})".toString()
             cfg['file'] = jar.outputs.files.singleFile.absolutePath
             cfg['extensions'] = extensions
+            cfg['env'] = simExtension.environment
             cfg['librarydir'] = libraryDir
             cfg['mainclass'] = mainClass
             cfgs << cfg

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/JavaSimulationTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/JavaSimulationTask.groovy
@@ -30,7 +30,7 @@ class JavaSimulationTask extends ExternalLaunchTask {
             java = (new File(jdkPath, javaFileName)).absolutePath.toString()
         }
 
-        environment = TestPlugin.getSimLaunchEnv(project, ldpath)
+        environment.putAll(TestPlugin.getSimLaunchEnv(project, ldpath))
         for (Jar jar : taskDependencies.getDependencies(this).findAll { it instanceof Jar } as Set<Jar>) {
             def manifestAttributes = jar.manifest.attributes
 

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/NativeExternalSimulationTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/NativeExternalSimulationTask.groovy
@@ -12,6 +12,7 @@ import org.gradle.nativeplatform.NativeExecutableBinarySpec
 import org.gradle.nativeplatform.tasks.InstallExecutable
 import org.gradle.nativeplatform.test.NativeTestSuiteBinarySpec
 import org.gradle.nativeplatform.toolchain.Clang
+import edu.wpi.first.gradlerio.wpi.simulation.SimulationExtension
 
 import java.nio.file.Paths
 
@@ -28,6 +29,7 @@ class NativeExternalSimulationTask extends ExternalSimulationTask {
     @TaskAction
     void create() {
         def cfgs = []
+        SimulationExtension simExtension = project.extensions.getByType(SimulationExtension)
         def extensions = TestPlugin.getHALExtensions(project)
         for (NativeExecutableBinarySpec binary : exeBinaries) {
             def cfg = [:]
@@ -36,6 +38,7 @@ class NativeExternalSimulationTask extends ExternalSimulationTask {
             cfg['extensions'] = extensions
             cfg['launchfile'] = Paths.get(installTask.installDirectory.asFile.get().toString(), 'lib', installTask.executableFile.asFile.get().name).toString()
             cfg['clang'] = binary.toolChain in Clang
+            cfg['env'] = simExtension.environment
 
             def srcpaths = []
             def headerpaths = []
@@ -71,6 +74,7 @@ class NativeExternalSimulationTask extends ExternalSimulationTask {
             cfg['extensions'] = extensions
             cfg['launchfile'] = Paths.get(installTask.installDirectory.asFile.get().toString(), 'lib', installTask.executableFile.asFile.get().name).toString()
             cfg['clang'] = binary.toolChain in Clang
+            cfg['env'] = simExtension.environment
 
             def srcpaths = []
             def headerpaths = []

--- a/src/main/groovy/edu/wpi/first/gradlerio/test/NativeSimulationTask.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/test/NativeSimulationTask.groovy
@@ -18,7 +18,7 @@ class NativeSimulationTask extends ExternalLaunchTask {
         def installTask = binary.tasks.withType(InstallExecutable).first()
         def dir = new File(installTask.installDirectory.asFile.get(), "lib")
 
-        environment = TestPlugin.getSimLaunchEnv(project, dir.absolutePath)
+        environment.putAll(TestPlugin.getSimLaunchEnv(project, dir.absolutePath))
 
         workingDir = dir
         launch("\"${installTask.runScriptFile.get().asFile.absolutePath}\"")

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIPlugin.groovy
@@ -20,6 +20,7 @@ import org.gradle.internal.logging.text.StyledTextOutput
 import edu.wpi.first.nativeutils.NativeUtils
 import edu.wpi.first.nativeutils.NativeUtilsExtension
 import edu.wpi.first.toolchain.configurable.CrossCompilerConfiguration
+import edu.wpi.first.gradlerio.wpi.simulation.SimulationExtension
 
 @CompileStatic
 class WPIPlugin implements Plugin<Project> {
@@ -27,6 +28,7 @@ class WPIPlugin implements Plugin<Project> {
 
     void apply(Project project) {
         WPIExtension wpiExtension = project.extensions.create("wpi", WPIExtension, project)
+        SimulationExtension simExtension = project.extensions.create("sim", SimulationExtension, project)
         logger = ETLoggerFactory.INSTANCE.create(this.class.simpleName)
 
         project.pluginManager.apply(WPIToolsPlugin)

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/simulation/HalSimExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/simulation/HalSimExtension.groovy
@@ -1,0 +1,16 @@
+package edu.wpi.first.gradlerio.wpi.simulation
+
+import groovy.transform.CompileStatic
+import javax.inject.Inject
+import org.gradle.api.Named
+
+@CompileStatic
+class HalSimExtension implements Named {
+    String name
+    String baseArtifact
+
+    @Inject
+    HalSimExtension(String name) {
+        this.name = name
+    }
+}

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/simulation/SimulationExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/simulation/SimulationExtension.groovy
@@ -1,0 +1,23 @@
+package edu.wpi.first.gradlerio.wpi.simulation
+
+import groovy.transform.CompileStatic
+import javax.inject.Inject
+import org.gradle.api.Project
+import org.gradle.api.NamedDomainObjectContainer
+
+@CompileStatic
+class SimulationExtension {
+    Map<String, String> environment = [:]
+
+    void envVar(String name, String value) {
+        environment[name] = value
+    }
+
+
+    private NamedDomainObjectContainer<HalSimExtension> extensions
+
+    @Inject
+    SimulationExtension(Project project) {
+        extensions = project.objects.domainObjectContainer(HalSimExtension)
+    }
+}


### PR DESCRIPTION
Replaces #466 

The way this works is completely different. Instead of setting on the individual tasks, theres a new global extension `sim` that is used. So the following block would be used, and replaces what was there.

```
sim {
  envVar "myVar", "value"
}
```

Since its a map, you can also do 

```
sim {
   environment "myVar", "value"
}
```

But I wanted to leave the old method there so its trivial to replace.

Theres also a hidden goodie that might make it for 2021 that will improve extensions as well :D