### PR TITLE
Load vendor libs only from their repos

### DIFF
--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIMavenRepo.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIMavenRepo.groovy
@@ -10,6 +10,7 @@ class WPIMavenRepo implements Named {
     int priority = PRIORITY_REPO
 
     String name;
+    String[] groups
 
     static final int PRIORITY_REPO = 100
     static final int PRIORITY_REPO_INUSE = 50

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIPlugin.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/WPIPlugin.groovy
@@ -140,6 +140,11 @@ class WPIPlugin implements Plugin<Project> {
                 project.repositories.maven { MavenArtifactRepository repo ->
                     repo.name = "WPI${mirror.name}Release"
                     repo.url = mirror.release
+                    repo.content {
+                        mirror.groups.each { group ->
+                            includeGroup(group)
+                        }
+                    }
                 }
         }
 

--- a/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIVendorDepsExtension.groovy
+++ b/src/main/groovy/edu/wpi/first/gradlerio/wpi/dependencies/WPIVendorDepsExtension.groovy
@@ -106,6 +106,12 @@ public class WPIVendorDepsExtension {
 
             if (dep != null && dep.mavenUrls != null) {
                 int i = 0
+
+                String[] groups
+                dep.javaDependencies.each {art -> groups << art.groupId}
+                dep.jniDependencies.each {art -> groups << art.groupId}
+                dep.cppDependencies.each {art -> groups << art.groupId}
+
                 dep.mavenUrls.each { url ->
                     // Only add if the maven doesn't yet exist.
                     if (wpiExt.maven.find { it.release.equals(url) } == null) {
@@ -113,6 +119,7 @@ public class WPIVendorDepsExtension {
                         log.info("Registering vendor dep maven: $name on project ${wpiExt.project.path}")
                         wpiExt.maven.vendor(name) { WPIMavenRepo repo ->
                             repo.release = url
+                            repo.groups = groups
                         }
                     }
                 }


### PR DESCRIPTION
Fixes #500 

#501 can possibly also fixed in this way, as well as an alternative to #489 (exclude WPILib deps from vendor repos - or just anything other than WPI's repos). 