### PR TITLE
Print image file contents when unable to parse image version

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/InvalidImageException.java
+++ b/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/InvalidImageException.java
@@ -40,5 +40,10 @@ public class InvalidImageException extends RuntimeException {
         this.imageVersion = "";
     }
 
+    public InvalidImageException(String imageFile) {
+        super("Could not parse image version!\n/etc/natinst/share/scs_imagemetadata.ini contents:\n" + imageFile);
+        allowedImageVersions = List.of();
+        this.imageVersion = "";
+    }
 
 }

--- a/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/RoboRIO.java
+++ b/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/RoboRIO.java
@@ -146,7 +146,7 @@ public class RoboRIO extends WPIRemoteTarget {
         }
 
         if (!imageFound) {
-            throw new InvalidImageException();
+            throw new InvalidImageException(content);
         }
     }
 


### PR DESCRIPTION
This will help for determining why the parsing failed

```
admin @ roborio-330-FRC.local: Connected.
  Reason: InvalidImageException
  Could not parse image version!
/etc/natinst/share/scs_imagemetadata.ini contents:
[ImageMetadata]
IMAGEDESCRIPTION = ""
IMAGEID = "{69BE94A1-A4B5-47BC-A41F-C60F0E5030A6}"
IMAGETITLE = "roboRIO Image"
IMAGEVERSION = "FRC_roboRIO99_2022_v3.2"
```