### PR TITLE
Updates to vendor configuration

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.java
@@ -116,9 +116,9 @@ public class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo>
         return mirr;
     }
 
-    public WPIMavenRepo vendor(String name, final Action<WPIMavenRepo> config) {
+    public WPIMavenRepo vendor(String name, final Action<WPIMavenRepo> config, boolean mavenUrlsInWpilibCache) {
         WPIMavenRepo mirr = project.getObjects().newInstance(WPIMavenRepo.class, name);
-        mirr.setPriority(WPIMavenRepo.PRIORITY_VENDOR);
+        mirr.setPriority(mavenUrlsInWpilibCache ? WPIMavenRepo.PRIORITY_VENDOR_ALLOWS_CACHE : WPIMavenRepo.PRIORITY_VENDOR_WITHOUT_CACHE);
         config.execute(mirr);
         this.add(mirr);
         return mirr;

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.java
@@ -6,6 +6,8 @@ import org.gradle.api.internal.DefaultNamedDomainObjectSet;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.internal.reflect.DirectInstantiator;
 
+import java.util.Set;
+
 import javax.inject.Inject;
 
 public class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo> {
@@ -35,6 +37,7 @@ public class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo>
             mirror.setRelease("https://frcmaven.wpi.edu/artifactory/release");
             mirror.setDevelopment("https://frcmaven.wpi.edu/artifactory/development");
             mirror.setPriority(WPIMavenRepo.PRIORITY_OFFICIAL);
+            mirror.setAllowedGroupIdsRegex(Set.of("edu\\.wpi\\.first\\..*"));
         });
 
         // mirror("AU") { WPIMavenRepo mirror ->

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.java
@@ -22,6 +22,7 @@ public class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo>
     private boolean useFrcMavenLocalRelease;
     private boolean useMavenCentral;
     private boolean useFrcMavenVendorCache;
+    private boolean limitFrcMavenToWPIDeps;
 
     @Inject
     public WPIMavenExtension(Project project) {
@@ -34,18 +35,20 @@ public class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo>
         this.useFrcMavenLocalRelease = false;
         this.useMavenCentral = true;
         this.useFrcMavenVendorCache = true;
-
-        mirror("Official", mirror -> {
-            mirror.setRelease("https://frcmaven.wpi.edu/artifactory/release");
-            mirror.setDevelopment("https://frcmaven.wpi.edu/artifactory/development");
-            mirror.setPriority(WPIMavenRepo.PRIORITY_OFFICIAL);
-            mirror.setAllowedGroupIdsRegex(Set.of("edu\\.wpi\\.first\\..*"));
-        });
+        this.limitFrcMavenToWPIDeps = true;
 
         // mirror("AU") { WPIMavenRepo mirror ->
         //     mirror.release = "http://wpimirror.imjac.in/m2/release"
         //     mirror.development = "http://wpimirror.imjac.in/m2/development"
         // }
+    }
+
+    public boolean isLimitFrcMavenToWPIDeps() {
+        return limitFrcMavenToWPIDeps;
+    }
+
+    public void setLimitFrcMavenToWPIDeps(boolean limitFrcMavenToWPIDeps) {
+        this.limitFrcMavenToWPIDeps = limitFrcMavenToWPIDeps;
     }
 
     public Set<String> getVendorCacheGroupIds() {

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.java
@@ -6,6 +6,7 @@ import org.gradle.api.internal.DefaultNamedDomainObjectSet;
 import org.gradle.api.internal.CollectionCallbackActionDecorator;
 import org.gradle.internal.reflect.DirectInstantiator;
 
+import java.util.HashSet;
 import java.util.Set;
 
 import javax.inject.Inject;
@@ -14,6 +15,7 @@ public class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo>
 
     private final Project project;
 
+    private final Set<String> vendorCacheGroupIds = new HashSet<>();
     private boolean useDevelopment;
     private boolean useLocal;
     private boolean useFrcMavenLocalDevelopment;
@@ -44,6 +46,10 @@ public class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo>
         //     mirror.release = "http://wpimirror.imjac.in/m2/release"
         //     mirror.development = "http://wpimirror.imjac.in/m2/development"
         // }
+    }
+
+    public Set<String> getVendorCacheGroupIds() {
+        return vendorCacheGroupIds;
     }
 
     public boolean isUseFrcMavenVendorCache() {

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.java
@@ -22,7 +22,7 @@ public class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo>
     private boolean useFrcMavenLocalRelease;
     private boolean useMavenCentral;
     private boolean useFrcMavenVendorCache;
-    private boolean limitFrcMavenToWPIDeps;
+    private boolean enableRepositoryGroupLimits;
 
     @Inject
     public WPIMavenExtension(Project project) {
@@ -35,7 +35,7 @@ public class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo>
         this.useFrcMavenLocalRelease = false;
         this.useMavenCentral = true;
         this.useFrcMavenVendorCache = true;
-        this.limitFrcMavenToWPIDeps = true;
+        this.enableRepositoryGroupLimits = true;
 
         // mirror("AU") { WPIMavenRepo mirror ->
         //     mirror.release = "http://wpimirror.imjac.in/m2/release"
@@ -43,12 +43,12 @@ public class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo>
         // }
     }
 
-    public boolean isLimitFrcMavenToWPIDeps() {
-        return limitFrcMavenToWPIDeps;
+    public boolean isEnableRepositoryGroupLimits() {
+        return enableRepositoryGroupLimits;
     }
 
-    public void setLimitFrcMavenToWPIDeps(boolean limitFrcMavenToWPIDeps) {
-        this.limitFrcMavenToWPIDeps = limitFrcMavenToWPIDeps;
+    public void setEnableRepositoryGroupLimits(boolean enableRepositoryGroupLimits) {
+        this.enableRepositoryGroupLimits = enableRepositoryGroupLimits;
     }
 
     public Set<String> getVendorCacheGroupIds() {

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenRepo.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenRepo.java
@@ -15,10 +15,12 @@ public class WPIMavenRepo implements Named {
     public static final int PRIORITY_REPO_INUSE = 50;
 
     public static final int PRIORITY_OFFICIAL = 150;
-    public static final int PRIORITY_MIRROR = 200;
+    public static final int PRIORITY_MIRROR = 250;
     public static final int PRIORITY_MIRROR_INUSE = 120;
 
-    public static final int PRIORITY_VENDOR = 175;
+    public static final int PRIORITY_VENDOR_WITHOUT_CACHE = 175;
+    public static final int PRIORITY_WPILIB_VENDOR_CACHE = 200;
+    public static final int PRIORITY_VENDOR_ALLOWS_CACHE = 225;
 
     @Inject
     public WPIMavenRepo(String name) {

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenRepo.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenRepo.java
@@ -1,5 +1,7 @@
 package edu.wpi.first.gradlerio.wpi;
 
+import java.util.Set;
+
 import javax.inject.Inject;
 
 import org.gradle.api.Named;
@@ -8,6 +10,7 @@ public class WPIMavenRepo implements Named {
     private String release = null;
     private String development = null;
     private int priority = PRIORITY_REPO;
+    private Set<String> allowedGroupIds;
 
     private String name;
 
@@ -25,6 +28,14 @@ public class WPIMavenRepo implements Named {
     @Inject
     public WPIMavenRepo(String name) {
         this.setName(name);
+    }
+
+    public Set<String> getAllowedGroupIds() {
+        return allowedGroupIds;
+    }
+
+    public void setAllowedGroupIds(Set<String> allowedGroupIds) {
+        this.allowedGroupIds = allowedGroupIds;
     }
 
     public String getRelease() {

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenRepo.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenRepo.java
@@ -11,6 +11,7 @@ public class WPIMavenRepo implements Named {
     private String development = null;
     private int priority = PRIORITY_REPO;
     private Set<String> allowedGroupIds;
+    private Set<String> allowedGroupIdsRegex;
 
     private String name;
 
@@ -28,6 +29,14 @@ public class WPIMavenRepo implements Named {
     @Inject
     public WPIMavenRepo(String name) {
         this.setName(name);
+    }
+
+    public Set<String> getAllowedGroupIdsRegex() {
+        return allowedGroupIdsRegex;
+    }
+
+    public void setAllowedGroupIdsRegex(Set<String> allowedGroupIdsRegex) {
+        this.allowedGroupIdsRegex = allowedGroupIdsRegex;
     }
 
     public Set<String> getAllowedGroupIds() {

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
@@ -30,7 +30,7 @@ public class WPIPlugin implements Plugin<Project> {
         project.getDependencies().registerTransform(UnzipTransform.class, variantTransform -> {
             variantTransform.getFrom().attribute(NATIVE_ARTIFACT_FORMAT, NATIVE_ARTIFACT_ZIP_TYPE);
             variantTransform.getTo().attribute(NATIVE_ARTIFACT_FORMAT, NATIVE_ARTIFACT_DIRECTORY_TYPE);
-          });
+        });
 
         WPIExtension wpiExtension = project.getExtensions().create("wpi", WPIExtension.class, project);
         logger = ETLoggerFactory.INSTANCE.create(this.getClass().getSimpleName());
@@ -42,12 +42,12 @@ public class WPIPlugin implements Plugin<Project> {
             task.setGroup("GradleRIO");
             task.setDescription("Print all versions of the wpi block");
             task.doLast(new Action<Task>() {
-				@Override
-				public void execute(Task arg0) {
-                                //     wpiExtension.versions().each { String key, Tuple tup ->
-            //         println "${tup.first()}: ${tup[1]} (${key})"
-            //     }
-				}
+                @Override
+                public void execute(Task arg0) {
+                    // wpiExtension.versions().each { String key, Tuple tup ->
+                    // println "${tup.first()}: ${tup[1]} (${key})"
+                    // }
+                }
             });
             // task.doLast {
 
@@ -58,10 +58,12 @@ public class WPIPlugin implements Plugin<Project> {
             task.setGroup("GradleRIO");
             task.setDescription("Explain all Maven Repos present on this project");
             task.doLast(new Action<Task>() {
-				@Override
-				public void execute(Task arg0) {
+
+                @Override
+                public void execute(Task arg0) {
                     explainRepositories(project);
-				}
+                }
+
             });
         });
 
@@ -105,9 +107,11 @@ public class WPIPlugin implements Plugin<Project> {
             });
         }
 
-        WPIMavenRepo[] sortedMirrors = wpi.getMaven().stream().sorted((a, b) -> a.getPriority() - b.getPriority()).toArray(WPIMavenRepo[]::new);
+        WPIMavenRepo[] sortedMirrors = wpi.getMaven().stream().sorted((a, b) -> a.getPriority() - b.getPriority())
+                .toArray(WPIMavenRepo[]::new);
 
-        // If enabled, the development branch should have a higher weight than the release
+        // If enabled, the development branch should have a higher weight than the
+        // release
         // branch.
         if (wpi.getMaven().isUseDevelopment()) {
             for (WPIMavenRepo mirror : sortedMirrors) {
@@ -115,13 +119,18 @@ public class WPIPlugin implements Plugin<Project> {
                     project.getRepositories().maven(repo -> {
                         repo.setName("WPI" + mirror.getName() + "Development");
                         repo.setUrl(mirror.getDevelopment());
-                        if (mirror.getAllowedGroupIds() != null) {
-                            repo.content(desc -> {
-                                for(String group : mirror.getAllowedGroupIds()) {
+                        repo.content(desc -> {
+                            if (mirror.getAllowedGroupIds() != null) {
+                                for (String group : mirror.getAllowedGroupIds()) {
                                     desc.includeGroup(group);
                                 }
-                            });
-                        }
+                            }
+                            if (mirror.getAllowedGroupIdsRegex() != null) {
+                                for (String group : mirror.getAllowedGroupIdsRegex()) {
+                                    desc.includeGroupByRegex(group);
+                                }
+                            }
+                        });
                     });
                 }
             }
@@ -134,7 +143,7 @@ public class WPIPlugin implements Plugin<Project> {
                     repo.setUrl(mirror.getRelease());
                     if (mirror.getAllowedGroupIds() != null) {
                         repo.content(desc -> {
-                            for(String group : mirror.getAllowedGroupIds()) {
+                            for (String group : mirror.getAllowedGroupIds()) {
                                 desc.includeGroup(group);
                             }
                         });

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
@@ -85,9 +85,7 @@ public class WPIPlugin implements Plugin<Project> {
             mirror.setRelease("https://frcmaven.wpi.edu/artifactory/release");
             mirror.setDevelopment("https://frcmaven.wpi.edu/artifactory/development");
             mirror.setPriority(WPIMavenRepo.PRIORITY_OFFICIAL);
-            if (wpi.getMaven().isLimitFrcMavenToWPIDeps()) {
-                mirror.setAllowedGroupIdsRegex(Set.of("edu\\.wpi\\.first\\..*"));
-            }
+            mirror.setAllowedGroupIdsRegex(Set.of("edu\\.wpi\\.first\\..*"));
         });
 
         if (wpi.getMaven().isUseFrcMavenVendorCache()) {
@@ -122,6 +120,8 @@ public class WPIPlugin implements Plugin<Project> {
         WPIMavenRepo[] sortedMirrors = wpi.getMaven().stream().sorted((a, b) -> a.getPriority() - b.getPriority())
                 .toArray(WPIMavenRepo[]::new);
 
+        boolean enableGroupLimits = wpi.getMaven().isEnableRepositoryGroupLimits();
+
         // If enabled, the development branch should have a higher weight than the
         // release
         // branch.
@@ -131,18 +131,20 @@ public class WPIPlugin implements Plugin<Project> {
                     project.getRepositories().maven(repo -> {
                         repo.setName("WPI" + mirror.getName() + "Development");
                         repo.setUrl(mirror.getDevelopment());
-                        repo.content(desc -> {
-                            if (mirror.getAllowedGroupIds() != null) {
-                                for (String group : mirror.getAllowedGroupIds()) {
-                                    desc.includeGroup(group);
+                        if (enableGroupLimits) {
+                            repo.content(desc -> {
+                                if (mirror.getAllowedGroupIds() != null) {
+                                    for (String group : mirror.getAllowedGroupIds()) {
+                                        desc.includeGroup(group);
+                                    }
                                 }
-                            }
-                            if (mirror.getAllowedGroupIdsRegex() != null) {
-                                for (String group : mirror.getAllowedGroupIdsRegex()) {
-                                    desc.includeGroupByRegex(group);
+                                if (mirror.getAllowedGroupIdsRegex() != null) {
+                                    for (String group : mirror.getAllowedGroupIdsRegex()) {
+                                        desc.includeGroupByRegex(group);
+                                    }
                                 }
-                            }
-                        });
+                            });
+                        }
                     });
                 }
             }
@@ -153,10 +155,17 @@ public class WPIPlugin implements Plugin<Project> {
                 project.getRepositories().maven(repo -> {
                     repo.setName("WPI" + mirror.getName() + "Release");
                     repo.setUrl(mirror.getRelease());
-                    if (mirror.getAllowedGroupIds() != null) {
+                    if (enableGroupLimits) {
                         repo.content(desc -> {
-                            for (String group : mirror.getAllowedGroupIds()) {
-                                desc.includeGroup(group);
+                            if (mirror.getAllowedGroupIds() != null) {
+                                for (String group : mirror.getAllowedGroupIds()) {
+                                    desc.includeGroup(group);
+                                }
+                            }
+                            if (mirror.getAllowedGroupIdsRegex() != null) {
+                                for (String group : mirror.getAllowedGroupIdsRegex()) {
+                                    desc.includeGroupByRegex(group);
+                                }
                             }
                         });
                     }

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
@@ -77,6 +77,13 @@ public class WPIPlugin implements Plugin<Project> {
     }
 
     void addMavenRepositories(Project project, WPIExtension wpi) {
+        if (wpi.getMaven().isUseFrcMavenVendorCache()) {
+            wpi.getMaven().repo("FRCMavenVendorCache", cache -> {
+                cache.setRelease("https://frcmaven.wpi.edu/ui/native/vendor-mvn-release/");
+                cache.setPriority(WPIMavenRepo.PRIORITY_WPILIB_VENDOR_CACHE);
+            });
+        }
+
         if (wpi.getMaven().isUseLocal()) {
             project.getRepositories().maven(repo -> {
                 repo.setName("WPILocal");
@@ -125,13 +132,6 @@ public class WPIPlugin implements Plugin<Project> {
         // Maven Central is needed for EJML and JUnit
         if (wpi.getMaven().isUseMavenCentral()) {
             project.getRepositories().mavenCentral();
-        }
-
-        if (wpi.getMaven().isUseFrcMavenVendorCache()) {
-            project.getRepositories().maven(repo -> {
-                repo.setName("FRCMavenVendorCache");
-                repo.setUrl("https://frcmaven.wpi.edu/ui/native/vendor-mvn-release/");
-            });
         }
     }
 }

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
@@ -1,5 +1,7 @@
 package edu.wpi.first.gradlerio.wpi;
 
+import java.util.Set;
+
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -79,6 +81,15 @@ public class WPIPlugin implements Plugin<Project> {
     }
 
     void addMavenRepositories(Project project, WPIExtension wpi) {
+        wpi.getMaven().mirror("Official", mirror -> {
+            mirror.setRelease("https://frcmaven.wpi.edu/artifactory/release");
+            mirror.setDevelopment("https://frcmaven.wpi.edu/artifactory/development");
+            mirror.setPriority(WPIMavenRepo.PRIORITY_OFFICIAL);
+            if (wpi.getMaven().isLimitFrcMavenToWPIDeps()) {
+                mirror.setAllowedGroupIdsRegex(Set.of("edu\\.wpi\\.first\\..*"));
+            }
+        });
+
         if (wpi.getMaven().isUseFrcMavenVendorCache()) {
             wpi.getMaven().repo("FRCMavenVendorCache", cache -> {
                 cache.setRelease("https://frcmaven.wpi.edu/ui/native/vendor-mvn-release/");

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
@@ -115,6 +115,13 @@ public class WPIPlugin implements Plugin<Project> {
                     project.getRepositories().maven(repo -> {
                         repo.setName("WPI" + mirror.getName() + "Development");
                         repo.setUrl(mirror.getDevelopment());
+                        if (mirror.getAllowedGroupIds() != null) {
+                            repo.content(desc -> {
+                                for(String group : mirror.getAllowedGroupIds()) {
+                                    desc.includeGroup(group);
+                                }
+                            });
+                        }
                     });
                 }
             }
@@ -125,6 +132,13 @@ public class WPIPlugin implements Plugin<Project> {
                 project.getRepositories().maven(repo -> {
                     repo.setName("WPI" + mirror.getName() + "Release");
                     repo.setUrl(mirror.getRelease());
+                    if (mirror.getAllowedGroupIds() != null) {
+                        repo.content(desc -> {
+                            for(String group : mirror.getAllowedGroupIds()) {
+                                desc.includeGroup(group);
+                            }
+                        });
+                    }
                 });
             }
         }

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
@@ -83,6 +83,7 @@ public class WPIPlugin implements Plugin<Project> {
             wpi.getMaven().repo("FRCMavenVendorCache", cache -> {
                 cache.setRelease("https://frcmaven.wpi.edu/ui/native/vendor-mvn-release/");
                 cache.setPriority(WPIMavenRepo.PRIORITY_WPILIB_VENDOR_CACHE);
+                cache.setAllowedGroupIds(wpi.getMaven().getVendorCacheGroupIds());
             });
         }
 

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/dependencies/WPIVendorDepsExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/dependencies/WPIVendorDepsExtension.java
@@ -131,12 +131,13 @@ public abstract class WPIVendorDepsExtension {
 
                     String name = dep.uuid + "_" + i++;
                     log.info("Registering vendor dep maven: " + name + " on project " + wpiExt.getProject().getPath());
-                    boolean allowsCache = dep.mavenUrlsInWpilibCache != null ? dep.mavenUrlsInWpilibCache : false; 
+                    boolean allowsCache = dep.mavenUrlsInWpilibCache != null ? dep.mavenUrlsInWpilibCache : false;
+                    if (allowsCache) {
+                        wpiExt.getMaven().getVendorCacheGroupIds().addAll(groupIds);
+                    }
                     wpiExt.getMaven().vendor(name, repo -> {
                         repo.setRelease(url);
-                        if (!groupIds.isEmpty()) {
-                            repo.setAllowedGroupIds(groupIds);
-                        }
+                        repo.setAllowedGroupIds(groupIds);
                     }, allowsCache);
                 }
             }

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/dependencies/WPIVendorDepsExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/dependencies/WPIVendorDepsExtension.java
@@ -14,7 +14,6 @@ import javax.inject.Inject;
 import com.google.gson.Gson;
 
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.provider.ProviderFactory;
 
 import edu.wpi.first.deployutils.log.ETLogger;
@@ -36,26 +35,16 @@ public abstract class WPIVendorDepsExtension {
         return new ArrayList<>(dependencies.values());
     }
 
-    // private final List<DelegatedDependencySet> nativeDependenciesList = new
-    // ArrayList<>();
-
-    // public List<DelegatedDependencySet> getNativeDependenciesList() {
-    // return nativeDependenciesList;
-    // }
-
     private final ETLogger log;
     private final Gson gson = new Gson();
 
     public static final String DEFAULT_VENDORDEPS_FOLDER_NAME = "vendordeps";
     public static final String GRADLERIO_VENDOR_FOLDER_PROPERTY = "gradlerio.vendordep.folder.path";
 
-    private final ProviderFactory providerFactory;
-
     @Inject
-    public WPIVendorDepsExtension(WPIExtension wpiExt, ProviderFactory providerFactory) {
+    public WPIVendorDepsExtension(WPIExtension wpiExt) {
         this.wpiExt = wpiExt;
         this.log = ETLoggerFactory.INSTANCE.create("WPIVendorDeps");
-        this.providerFactory = providerFactory;
     }
 
     private File vendorFolder(Project project) {
@@ -123,7 +112,8 @@ public abstract class WPIVendorDepsExtension {
                 if (wpiExt.getMaven().matching(x -> x.getRelease().equals(url)).isEmpty()) {
                     String name = dep.uuid + "_" + i++;
                     log.info("Registering vendor dep maven: " + name + " on project " + wpiExt.getProject().getPath());
-                    wpiExt.getMaven().vendor(name, repo -> repo.setRelease(url));
+                    boolean allowsCache = dep.mavenUrlsInWpilibCache != null ? dep.mavenUrlsInWpilibCache : false; 
+                    wpiExt.getMaven().vendor(name, repo -> repo.setRelease(url), allowsCache);
                 }
             }
         }
@@ -177,6 +167,7 @@ public abstract class WPIVendorDepsExtension {
         public String name;
         public String version;
         public String uuid;
+        public Boolean mavenUrlsInWpilibCache;
         public String[] mavenUrls;
         public String jsonUrl;
         public String fileName;


### PR DESCRIPTION
This PR is a few changes. The first is updates to the frc maven vendor cache. This allows vendors to state if theyre included or not in the cache. This will speed up builds for vendors not in the cache.

Secondly, this adds repository filtering. This means that for vendors only group ids listed by the vendors will be searched. Closes #500 

Both of these changes are backwards compatible. Old vendor deps will still work, and they default to not being included in the cache.