### PR TITLE
Use correct vendor cache url

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenExtension.java
@@ -128,9 +128,9 @@ public class WPIMavenExtension extends DefaultNamedDomainObjectSet<WPIMavenRepo>
         return mirr;
     }
 
-    public WPIMavenRepo vendor(String name, final Action<WPIMavenRepo> config, boolean mavenUrlsInWpilibCache) {
+    public WPIMavenRepo vendor(String name, final Action<WPIMavenRepo> config) {
         WPIMavenRepo mirr = project.getObjects().newInstance(WPIMavenRepo.class, name);
-        mirr.setPriority(mavenUrlsInWpilibCache ? WPIMavenRepo.PRIORITY_VENDOR_ALLOWS_CACHE : WPIMavenRepo.PRIORITY_VENDOR_WITHOUT_CACHE);
+        mirr.setPriority(WPIMavenRepo.PRIORITY_VENDOR);
         config.execute(mirr);
         this.add(mirr);
         return mirr;

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenRepo.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIMavenRepo.java
@@ -22,9 +22,8 @@ public class WPIMavenRepo implements Named {
     public static final int PRIORITY_MIRROR = 250;
     public static final int PRIORITY_MIRROR_INUSE = 120;
 
-    public static final int PRIORITY_VENDOR_WITHOUT_CACHE = 175;
     public static final int PRIORITY_WPILIB_VENDOR_CACHE = 200;
-    public static final int PRIORITY_VENDOR_ALLOWS_CACHE = 225;
+    public static final int PRIORITY_VENDOR = 225;
 
     @Inject
     public WPIMavenRepo(String name) {

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
@@ -90,7 +90,7 @@ public class WPIPlugin implements Plugin<Project> {
 
         if (wpi.getMaven().isUseFrcMavenVendorCache()) {
             wpi.getMaven().repo("FRCMavenVendorCache", cache -> {
-                cache.setRelease("https://frcmaven.wpi.edu/ui/native/vendor-mvn-release/");
+                cache.setRelease("https://frcmaven.wpi.edu/artifactory/vendor-mvn-release");
                 cache.setPriority(WPIMavenRepo.PRIORITY_WPILIB_VENDOR_CACHE);
                 cache.setAllowedGroupIds(wpi.getMaven().getVendorCacheGroupIds());
             });

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/dependencies/WPIVendorDepsExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/dependencies/WPIVendorDepsExtension.java
@@ -137,14 +137,11 @@ public abstract class WPIVendorDepsExtension {
                 if (!found) {
                     String name = dep.uuid + "_" + i++;
                     log.info("Registering vendor dep maven: " + name + " on project " + wpiExt.getProject().getPath());
-                    boolean allowsCache = dep.mavenUrlsInWpilibCache != null ? dep.mavenUrlsInWpilibCache : false;
-                    if (allowsCache) {
-                        wpiExt.getMaven().getVendorCacheGroupIds().addAll(groupIds);
-                    }
+                    wpiExt.getMaven().getVendorCacheGroupIds().addAll(groupIds);
                     wpiExt.getMaven().vendor(name, repo -> {
                         repo.setRelease(url);
                         repo.setAllowedGroupIds(groupIds);
-                    }, allowsCache);
+                    });
                 }
             }
         }
@@ -198,7 +195,6 @@ public abstract class WPIVendorDepsExtension {
         public String name;
         public String version;
         public String uuid;
-        public Boolean mavenUrlsInWpilibCache;
         public String[] mavenUrls;
         public String[] extraGroupIds;
         public String jsonUrl;


### PR DESCRIPTION
The incorrect URL was causing the UI URL to be used, causing the cache to be much slower, especially if there were artifacts not in the cache. This had us add a new field to the vendor json spec. But with the right URL, this is not longer necessary.