### PR TITLE
Add a way to not use the GradleRIO-default JVM args

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/FRCJavaArtifact.java
+++ b/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/FRCJavaArtifact.java
@@ -25,6 +25,8 @@ public class FRCJavaArtifact extends DebuggableJavaArtifact {
     private final List<String> jvmArgs = new ArrayList<>();
     private final List<String> arguments = new ArrayList<>();
 
+    private boolean useDefaultJvmArgs = true;
+
     private final RoboRIO roboRIO;
 
     @Inject
@@ -116,12 +118,26 @@ public class FRCJavaArtifact extends DebuggableJavaArtifact {
         return arguments;
     }
 
+    public void useDefaultJvmArgs(boolean useDefaultJvmArgs) {
+        this.useDefaultJvmArgs = useDefaultJvmArgs;
+    }
+
     private String generateStartCommand(DeployContext ctx) {
         StringBuilder builder = new StringBuilder();
-        builder.append("/usr/local/frc/JRE/bin/java -XX:+UseConcMarkSweepGC -Djava.library.path=");
+        builder.append("/usr/local/frc/JRE/bin/java");
+        builder.append(" -Djava.library.path=");
         builder.append(FRCDeployPlugin.LIB_DEPLOY_DIR);
-        builder.append(" -Djava.lang.invoke.stringConcat=BC_SB ");
-        builder.append(String.join(" ", jvmArgs));
+
+        String jvmArgsString = String.join(" ", jvmArgs);
+        if(useDefaultJvmArgs) {
+            builder.append(" -Djava.lang.invoke.stringConcat=BC_SB ");
+            builder.append(" -XX:+UseConcMarkSweepGC ");
+        } else {
+            ctx.getLogger().warn("You're not using the default JVM args: things might not work as expected!\n"
+                                + "Your custom JVM args are: " + jvmArgsString);
+        }
+
+        builder.append(jvmArgsString);
         builder.append(" ");
 
         // Debug stuff

--- a/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/FRCJavaArtifact.java
+++ b/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/FRCJavaArtifact.java
@@ -133,7 +133,7 @@ public class FRCJavaArtifact extends DebuggableJavaArtifact {
             builder.append(" -Djava.lang.invoke.stringConcat=BC_SB ");
             builder.append(" -XX:+UseConcMarkSweepGC ");
         } else {
-            ctx.getLogger().warn("You're not using the default JVM args: things might not work as expected!\n"
+            ctx.getLogger().log("You're not using the default JVM args: things might not work as expected!\n"
                                 + "Your custom JVM args are: " + jvmArgsString);
         }
 


### PR DESCRIPTION
Resolves #564 

I hope that this can be used for the JDK17 experiments (among other usecases):
```gradle
deploy.targets.roborio(getTargetTypeClass('RoboRIO')) {
         // Team number is loaded either from the .wpilib/wpilib_preferences.json
         // or from command line. If not found an exception will be thrown.
         // You can use getTeamOrDefault(team) instead of getTeamNumber if you
         // want to store a team number in this file.
         team = project.frc.getTeamNumber()
         debug = project.frc.getDebugOrDefault(false)

         artifacts {
             // First part is artifact name, 2nd is artifact type
             // getTargetTypeClass is a shortcut to get the class type using a string

             frcJava(getArtifactTypeClass('FRCJavaArtifact')) {
                 useDefaultJvmArgs false
                 getJvmArgs() << "-XX:+UseG1GC -XX:MaxGCPauseMillis=1 -XX:+AlwaysPreTouch -XX:GCTimeRatio=1"
             }

             // Static files artifact ...
         }
}
```
Would this work?