### PR TITLE
Explicitly require python3

### DIFF
--- a/src/main/resources/ScriptBase.py
+++ b/src/main/resources/ScriptBase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import sys


### PR DESCRIPTION
Fixes macOS pop-up and Ubuntu 20.04