### PR TITLE
Allow Self-Signed Certificates for SSL

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/dependencies/VendorDepTask.java
@@ -117,6 +117,7 @@ public class VendorDepTask extends DefaultTask {
     private void downloadRemote(Path dest) throws IOException {
         downloadAction.src(url);
         downloadAction.dest(dest.toFile());
+        downloadAction.acceptAnyCertificate(true); // Allow self-signed certificates.
         downloadAction.execute();
     }
 }


### PR DESCRIPTION
Networks which use self-signed certificates to enable HTTPS monitoring, like some school networks, would not be able to download because of a SSL validation error. This should probably be enabled via a configuration setting which may be in a future commit.