### PR TITLE
Update native utils to 2023.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,16 +8,17 @@ plugins {
 }
 
 repositories {
+    mavenLocal()
     maven {
         url "https://plugins.gradle.org/m2/"
     }
-    mavenLocal()
+
 }
 
 dependencies {
     api 'com.google.code.gson:gson:2.8.6'
 
-    api 'edu.wpi.first:native-utils:2023.2.8'
+    api 'edu.wpi.first:native-utils:2023.4.0'
 
     api 'de.undercouch:gradle-download-task:4.1.2'
 
@@ -43,6 +44,10 @@ allprojects {
 
     if (project.hasProperty('publishVersion')) {
         version = project.publishVersion
+    }
+
+    tasks.withType(Javadoc) {
+        options.addBooleanOption('Xdoclint:all,-missing', true)
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,11 +8,10 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     maven {
         url "https://plugins.gradle.org/m2/"
     }
-
+    mavenLocal()
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 dependencies {
     api 'com.google.code.gson:gson:2.8.6'
 
-    api 'edu.wpi.first:native-utils:2023.4.0'
+    api 'edu.wpi.first:native-utils:2023.4.1'
 
     api 'de.undercouch:gradle-download-task:4.1.2'
 


### PR DESCRIPTION
Theres major changes to both the deploy and toolchain plugins. The toolchain plugin is a bit lazier now, which should make windows configuration faster. The deploy plugin now no longer uses static fields to share state to workers, which should be cleaner, and less chance of breaking.