### PR TITLE
Remove AlwaysPreTouch from java arguments

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/FRCJavaArtifact.java
+++ b/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/FRCJavaArtifact.java
@@ -36,7 +36,6 @@ public class FRCJavaArtifact extends DebuggableJavaArtifact {
         super(name, target);
         roboRIO = target;
 
-        jvmArgs.add("-XX:+AlwaysPreTouch");
         jvmArgs.add("-Djava.lang.invoke.stringConcat=BC_SB");
         jvmArgs.add("-Djava.library.path=" + FRCDeployPlugin.LIB_DEPLOY_DIR);
 


### PR DESCRIPTION
This was a good idea in theory, but with the limited ram resources on the roboRIO this can result in issues