### PR TITLE
Force .sh scripts to always be pulled as lf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
The overwrite for frcKillRobot.sh was getting corrupted by default on windows