### PR TITLE
Increase ssh timeout from 3 to 7 seconds

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/RoboRIO.java
+++ b/src/main/java/edu/wpi/first/gradlerio/deploy/roborio/RoboRIO.java
@@ -37,6 +37,10 @@ public class RoboRIO extends WPIRemoteTarget {
 
         setMaxChannels(4);
 
+        // Increase timeout. The only time this is really used is if the host is resolved,
+        // but takes forever to connect, which can happen if the CPU is loaded.
+        setTimeout(7);
+
         setOnlyIf(ctx -> verifyOnlyIf(ctx));
 
         // Make a copy of valid image versions so user defined cannot modify the global array


### PR DESCRIPTION
https://github.com/wpilibsuite/allwpilib/issues/6257 was causing the CPU to spin. Due to this, ssh took about 4 seconds to connect, which is higher than the timeout of 3 seconds, so it wouldn't connect. Increase the timeout to attempt to make this case still work.