### PR TITLE
Fix build artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         name: Maven
         path: ~/.m2/
+        include-hidden-files: true
 
   test_examples:
     needs: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/upload-artifact@v4
       with:
         name: Maven
-        path: ~/.m2/
+        path: ~/.m2/repository/
         include-hidden-files: true
 
   test_examples:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
       with:
         name: Maven
         path: ~/.m2/repository/
-        include-hidden-files: true
 
   test_examples:
     needs: build


### PR DESCRIPTION
Files/directories starting with `.` are now considered "hidden" and won't be uploaded by default. Uploading only the repository makes it so .m2 isn't in the recursive glob, and ensures settings.xml doesn't get uploaded (good practice since it can potentially contain repository credentials)
