### PR TITLE
Add Maven Respositories on Plugin Apply

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
@@ -70,9 +70,7 @@ public class WPIPlugin implements Plugin<Project> {
             });
         });
 
-        project.afterEvaluate(ae -> {
-            addMavenRepositories(project, wpiExtension);
-        });
+        addMavenRepositories(project, wpiExtension);
     }
 
     void explainRepositories(Project project) {


### PR DESCRIPTION
The `WPIPlugin` currently adds WPILibs maven repositories on afterEvaluate, which from how I understand Gradle, shouldn't work even though it does. When I try to use `build.gradle.kts`, instead of `build.gradle`, the repositories are declared after it attempts dependency resolution making it unusable.

I don't believe there should be any issues with adding the repositories in `apply`, but please correct me if I'm wrong.