### PR TITLE
Fix systemcore c++ deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:
@@ -24,7 +24,7 @@ jobs:
 
   test_examples:
     needs: build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
      matrix:
         language: [cpp, java] #, asm, jni]
@@ -49,7 +49,7 @@ jobs:
 
   publish:
     needs: [build, test_examples]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/src/main/java/edu/wpi/first/gradlerio/deploy/systemcore/FRCNativeArtifact.java
+++ b/src/main/java/edu/wpi/first/gradlerio/deploy/systemcore/FRCNativeArtifact.java
@@ -89,6 +89,9 @@ public class FRCNativeArtifact extends DebuggableNativeArtifact {
 
     private String generateStartCommand(DeployContext ctx) {
         StringBuilder builder = new StringBuilder();
+        builder.append("LD_LIBRARY_PATH=\"");
+        builder.append(FRCDeployPlugin.LIB_DEPLOY_DIR);
+        builder.append("\" ");
         boolean debug = systemCore.getDebug().get();
         if (debug) {
             builder.append("gdbserver host:");

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIVersionsExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIVersionsExtension.java
@@ -6,23 +6,23 @@ import org.gradle.api.provider.Property;
 
 public abstract class WPIVersionsExtension {
 
-    private static final String wpilibVersion = "2025.1.1-beta-2-41-g38b09a6";
-    private static final String opencvVersion = "4.8.0-2";
+    private static final String wpilibVersion = "2025.1.1-beta-2-79-g6ba7189";
+    private static final String opencvVersion = "4.10.0-3";
     private static final String imguiVersion = "1.89.9-1";
     private static final String ejmlVersion = "0.43.1";
     private static final String jacksonVersion = "2.15.2";
     private static final String quickbufVersion = "1.3.3";
-    private static final String wpimathVersion = "2025.1.1-beta-2-41-g38b09a6";
+    private static final String wpimathVersion = "2025.1.1-beta-2-79-g6ba7189";
 
     private static final String smartDashboardVersion = "2025.1.1-beta-2";
     private static final String shuffleboardVersion = "2025.1.1-beta-2";
-    private static final String outlineViewerVersion = "2025.1.1-beta-2-41-g38b09a6";
+    private static final String outlineViewerVersion = "2025.1.1-beta-2-79-g6ba7189";
     private static final String robotBuilderVersion = "2025.1.1-beta-2";
     private static final String pathWeaverVersion = "2025.1.1-beta-2";
-    private static final String glassVersion = "2025.1.1-beta-2-41-g38b09a6";
-    private static final String sysIdVersion = "2025.1.1-beta-2-41-g38b09a6";
-    private static final String roboRIOTeamNumberSetterVersion = "2025.1.1-beta-2-41-g38b09a6";
-    private static final String dataLogToolVersion = "2025.1.1-beta-2-41-g38b09a6";
+    private static final String glassVersion = "2025.1.1-beta-2-79-g6ba7189";
+    private static final String sysIdVersion = "2025.1.1-beta-2-79-g6ba7189";
+    private static final String roboRIOTeamNumberSetterVersion = "2025.1.1-beta-2-79-g6ba7189";
+    private static final String dataLogToolVersion = "2025.1.1-beta-2-79-g6ba7189";
 
 
     public abstract Property<String> getWpilibVersion();


### PR DESCRIPTION
ldconfig doesn't currently work, so we need to directly pass LD_LIBRARY_PATH for C++. 

Also updates the included library version. This includes working CAN and PWM support.