### PR TITLE
Fix arm64 linux simulation

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/wpi/simulation/SimulationExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/simulation/SimulationExtension.java
@@ -99,6 +99,7 @@ public class SimulationExtension {
 
         PatternFilterable filterable = new PatternSet();
         filterable.include("**/*.so*", "**/*.dylib", "**/*.pdb", "**/*.dll");
+        filterable.exclude("**/*.so.debug", "**/*.so.*.debug");
 
         debugArtifactView = debugConfiguration.getIncoming().artifactView(viewConfiguration -> {
             viewConfiguration.attributes(attributeContainer -> {


### PR DESCRIPTION
Desktop platforms don't split out debug info, but arm platforms do. The logic we used didn't account for this.

Closes https://github.com/wpilibsuite/allwpilib/issues/7631