### PR TITLE
Remove old java tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,7 @@ Windows Users: It is recommended to use Powershell instead of CMD. You can switc
 ### Tools
 
 - `./gradlew Glass` will launch Glass, a data visualization tool similar to the SimGUI.
-- `./gradlew ShuffleBoard` will launch Shuffleboard, the 2018 replacement for SmartDashboard.
-- `./gradlew SmartDashboard` will launch Smart Dashboard (note: SmartDashboard is legacy software, use ShuffleBoard instead!).
-- `./gradlew RobotBuilder` will launch Robot Builder, a tool for generating robot projects and source files.
 - `./gradlew OutlineViewer` will launch Outline Viewer, for viewing NetworkTables.
-- `./gradlew PathWeaver` will launch PathWeaver, a tool for generating motion profiles using WPILib's trajectories and splines.
 
 **At Competition? Connected to the Robot?** Run with the `--offline` flag. e.g. `./gradlew deploy --offline`
 

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIVersionsExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIVersionsExtension.java
@@ -14,14 +14,9 @@ public abstract class WPIVersionsExtension {
     private static final String quickbufVersion = "1.3.3";
     private static final String wpimathVersion = "2025.3.2-123-g22d12d2";
 
-    private static final String smartDashboardVersion = "2025.1.1-beta-2";
-    private static final String shuffleboardVersion = "2025.1.1-beta-2";
     private static final String outlineViewerVersion = "2025.3.2-123-g22d12d2";
-    private static final String robotBuilderVersion = "2025.1.1-beta-2";
-    private static final String pathWeaverVersion = "2025.1.1-beta-2";
     private static final String glassVersion = "2025.3.2-123-g22d12d2";
     private static final String sysIdVersion = "2025.3.2-123-g22d12d2";
-    private static final String roboRIOTeamNumberSetterVersion = "2025.1.1-beta-3-86-g666d163";
     private static final String dataLogToolVersion = "2025.3.2-123-g22d12d2";
 
 
@@ -33,11 +28,7 @@ public abstract class WPIVersionsExtension {
     public abstract Property<String> getEjmlVersion();
     public abstract Property<String> getJacksonVersion();
     public abstract Property<String> getQuickbufVersion();
-    public abstract Property<String> getSmartDashboardVersion();
-    public abstract Property<String> getShuffleboardVersion();
     public abstract Property<String> getOutlineViewerVersion();
-    public abstract Property<String> getRobotBuilderVersion();
-    public abstract Property<String> getPathWeaverVersion();
     public abstract Property<String> getGlassVersion();
     public abstract Property<String> getSysIdVersion();
     public abstract Property<String> getRoboRIOTeamNumberSetterVersion();
@@ -53,14 +44,9 @@ public abstract class WPIVersionsExtension {
         getEjmlVersion().convention(ejmlVersion);
         getJacksonVersion().convention(jacksonVersion);
         getQuickbufVersion().convention(quickbufVersion);
-        getSmartDashboardVersion().convention(smartDashboardVersion);
-        getShuffleboardVersion().convention(shuffleboardVersion);
         getOutlineViewerVersion().convention(outlineViewerVersion);
-        getRobotBuilderVersion().convention(robotBuilderVersion);
-        getPathWeaverVersion().convention(pathWeaverVersion);
         getGlassVersion().convention(glassVersion);
         getSysIdVersion().convention(sysIdVersion);
-        getRoboRIOTeamNumberSetterVersion().convention(roboRIOTeamNumberSetterVersion);
         getDataLogToolVersion().convention(dataLogToolVersion);
     }
 

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/dependencies/tools/WPIToolsPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/dependencies/tools/WPIToolsPlugin.java
@@ -24,19 +24,6 @@ public class WPIToolsPlugin implements Plugin<Project> {
         Provider<Directory> frcHome = wpi.getFrcHome();
         Provider<Directory> toolsFolder = project.provider(() -> frcHome.get().dir("tools"));
 
-        String toolsClassifier = project.getExtensions().getByType(WPIExtension.class).getToolsClassifier();
-        if (!toolsClassifier.equals("macarm64")) {
-            tools.add(new WPITool(project, "SmartDashboard", wpi.getVersions().getSmartDashboardVersion(),
-                    "edu.wpi.first.tools", "SmartDashboard", true, toolsFolder));
-        }
-
-        tools.add(new WPITool(project, "ShuffleBoard", wpi.getVersions().getShuffleboardVersion(),
-                "edu.wpi.first.tools", "Shuffleboard", true, toolsFolder));
-        tools.add(new WPITool(project, "RobotBuilder", wpi.getVersions().getRobotBuilderVersion(),
-                "edu.wpi.first.tools", "RobotBuilder", false, toolsFolder));
-        tools.add(new WPITool(project, "PathWeaver", wpi.getVersions().getPathWeaverVersion(), "edu.wpi.first.tools",
-                "PathWeaver", true, toolsFolder));
-
         cppTools.add(new WPICppTool(project, "OutlineViewer", wpi.getVersions().getOutlineViewerVersion(),
                 "edu.wpi.first.tools:OutlineViewer", toolsFolder));
         cppTools.add(
@@ -45,9 +32,6 @@ public class WPIToolsPlugin implements Plugin<Project> {
         cppTools.add(
                 new WPICppTool(project, "SysId", wpi.getVersions().getSysIdVersion(), "edu.wpi.first.tools:SysId",
                         toolsFolder));
-        cppTools.add(new WPICppTool(project, "roboRIOTeamNumberSetter",
-                wpi.getVersions().getRoboRIOTeamNumberSetterVersion(), "edu.wpi.first.tools:roboRIOTeamNumberSetter",
-                toolsFolder));
         cppTools.add(new WPICppTool(project, "DataLogTool", wpi.getVersions().getDataLogToolVersion(),
                 "edu.wpi.first.tools:DataLogTool", toolsFolder));
 

--- a/versionupdates.gradle
+++ b/versionupdates.gradle
@@ -1,14 +1,9 @@
 
 def versionMap = [
   wpilibVersion: 'edu.wpi.first.wpilibj:wpilibj-java:+',
-  // smartDashboardVersion: 'edu.wpi.first.tools:SmartDashboard:+:win64',
   outlineViewerVersion: 'edu.wpi.first.tools:OutlineViewer:+:windowsx86-64@zip',
-  // robotBuilderVersion: 'edu.wpi.first.tools:RobotBuilder:+',
-  // shuffleboardVersion: 'edu.wpi.first.tools:Shuffleboard:+:win64',
-  // pathWeaverVersion: 'edu.wpi.first.tools:PathWeaver:+:win64',
   glassVersion: 'edu.wpi.first.tools:Glass:+:windowsx86-64@zip',
   sysIdVersion: 'edu.wpi.first.tools:SysId:+:windowsx86-64@zip',
-  roboRIOTeamNumberSetterVersion: 'edu.wpi.first.tools:roboRIOTeamNumberSetter:+:windowsx86-64@zip',
   dataLogToolVersion: 'edu.wpi.first.tools:DataLogTool:+:windowsx86-64@zip',
   opencvVersion: 'edu.wpi.first.thirdparty.frc2025.opencv:opencv-java:+',
   imguiVersion: 'edu.wpi.first.thirdparty.frc2024:imgui:+:headers',


### PR DESCRIPTION
These tools are no longer shipped as part of 2027, and break the installer if they're in here.