### PR TITLE
Add all discovered modules from the classpath to compile tasks

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIModulesPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIModulesPlugin.java
@@ -19,6 +19,18 @@ public class WPIModulesPlugin implements Plugin<Project> {
   public void apply(Project project) {
     project.getTasks().withType(JavaCompile.class).forEach(compileJava -> {
       compileJava.doFirst((task) -> {
+        // Find all modular JAR files on the classpath, extract their module names (which may be different from
+        // the names of the containing JARs!), and pass those module names to the compile task using the --add-modules
+        // command line flag.
+        //
+        // --module-path is added as well so the compiler knows where to find those modules
+        //
+        // This is compatible with the modularity.inferModulePath setting that users can apply themselves (and which
+        // defaults to `true` in modern versions of Gradle), and is also compatible with user programs that manually
+        // specify a module-info.java file.  We primarily expect our users not to write a module-info file, though,
+        // but still want to allow them to use `import module` statements. Thus, this plugin.
+        //
+        // See: https://dev.java/learn/modules/add-modules-reads/
         var moduleFinder =
             ModuleFinder.of(compileJava.getClasspath().getFiles().stream().map(File::toPath).toArray(Path[]::new));
         var moduleNames =

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIModulesPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIModulesPlugin.java
@@ -36,17 +36,17 @@ public class WPIModulesPlugin implements Plugin<Project> {
         var moduleNames =
             moduleFinder.findAll().stream().map(mod -> mod.descriptor().name()).collect(Collectors.joining(","));
 
+        project.getLogger().debug("Adding modules to the compile task `{}`:", compileJava.getName());
+        moduleFinder.findAll().stream().sorted(Comparator.comparing(mod -> mod.descriptor().name())).forEach(mod -> {
+          project.getLogger().debug("Adding module {} from {}", mod.descriptor().name(), mod.location().map(URI::toString).orElse("<unknown location>"));
+        });
+
         var compilerArgs = new ArrayList<>(compileJava.getOptions().getCompilerArgs());
         compilerArgs.add("--module-path");
         compilerArgs.add(compileJava.getClasspath().getAsPath());
 
         compilerArgs.add("--add-modules");
         compilerArgs.add(moduleNames);
-
-        project.getLogger().debug("Adding modules to the compile task `{}`:", compileJava.getName());
-        moduleFinder.findAll().stream().sorted(Comparator.comparing(mod -> mod.descriptor().name())).forEach(mod -> {
-          project.getLogger().debug("Adding module {} from {}", mod.descriptor().name(), mod.location().map(URI::toString).orElse("<unknown location>"));
-        });
 
         compileJava.getOptions().setCompilerArgs(compilerArgs);
       });

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIModulesPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIModulesPlugin.java
@@ -1,0 +1,43 @@
+package edu.wpi.first.gradlerio.wpi;
+
+import java.io.File;
+import java.lang.module.ModuleFinder;
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.stream.Collectors;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+/**
+ * Configures java compilation tasks to automatically make available every module detected on the classpath.
+ */
+public class WPIModulesPlugin implements Plugin<Project> {
+  @Override
+  public void apply(Project project) {
+    project.getTasks().withType(JavaCompile.class).forEach(compileJava -> {
+      compileJava.doFirst((task) -> {
+        var moduleFinder =
+            ModuleFinder.of(compileJava.getClasspath().getFiles().stream().map(File::toPath).toArray(Path[]::new));
+        var moduleNames =
+            moduleFinder.findAll().stream().map(mod -> mod.descriptor().name()).collect(Collectors.joining(","));
+
+        var compilerArgs = new ArrayList<>(compileJava.getOptions().getCompilerArgs());
+        compilerArgs.add("--module-path");
+        compilerArgs.add(compileJava.getClasspath().getAsPath());
+
+        compilerArgs.add("--add-modules");
+        compilerArgs.add(moduleNames);
+
+        project.getLogger().debug("Adding modules to the compile task `{}`:", compileJava.getName());
+        moduleFinder.findAll().stream().sorted(Comparator.comparing(mod -> mod.descriptor().name())).forEach(mod -> {
+          project.getLogger().debug("Adding module {} from {}", mod.descriptor().name(), mod.location().map(URI::toString).orElse("<unknown location>"));
+        });
+
+        compileJava.getOptions().setCompilerArgs(compilerArgs);
+      });
+    });
+  }
+}

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIModulesPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIModulesPlugin.java
@@ -4,21 +4,22 @@ import java.io.File;
 import java.lang.module.ModuleFinder;
 import java.net.URI;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.tasks.compile.JavaCompile;
 
 /**
- * Configures java compilation tasks to automatically make available every module detected on the classpath.
+ * Configures java compilation tasks to automatically make available every module detected on the classpath. Automatic
+ * modules will not be included.
  */
 public class WPIModulesPlugin implements Plugin<Project> {
   @Override
   public void apply(Project project) {
     project.getTasks().withType(JavaCompile.class).forEach(compileJava -> {
-      compileJava.doFirst((task) -> {
+      compileJava.doFirst(task -> {
         // Find all modular JAR files on the classpath, extract their module names (which may be different from
         // the names of the containing JARs!), and pass those module names to the compile task using the --add-modules
         // command line flag.
@@ -31,24 +32,39 @@ public class WPIModulesPlugin implements Plugin<Project> {
         // but still want to allow them to use `import module` statements. Thus, this plugin.
         //
         // See: https://dev.java/learn/modules/add-modules-reads/
+        var classpathJars =
+            compileJava.getClasspath().getFiles().stream()
+                .map(File::toPath)
+                .filter(p -> p.getFileName().toString().endsWith(".jar"))
+                .toList();
+
         var moduleFinder =
-            ModuleFinder.of(compileJava.getClasspath().getFiles().stream().map(File::toPath).toArray(Path[]::new));
-        var moduleNames =
-            moduleFinder.findAll().stream().map(mod -> mod.descriptor().name()).collect(Collectors.joining(","));
+            ModuleFinder.of(classpathJars.toArray(Path[]::new));
+
+        // Select only explicit modules. Automatic modules may not actually be compatible with the JPMS; notably,
+        // EJML splits packages across multiple JARs, which is not permitted by the module system.
+        var modules = moduleFinder.findAll().stream()
+            .filter(mod -> !mod.descriptor().isAutomatic())
+            .sorted(Comparator.comparing(mod -> mod.descriptor().name()))
+            .toList();
 
         project.getLogger().debug("Adding modules to the compile task `{}`:", compileJava.getName());
-        moduleFinder.findAll().stream().sorted(Comparator.comparing(mod -> mod.descriptor().name())).forEach(mod -> {
-          project.getLogger().debug("Adding module {} from {}", mod.descriptor().name(), mod.location().map(URI::toString).orElse("<unknown location>"));
+        modules.forEach(mod -> {
+          project.getLogger().debug(
+              "Adding module {} from {}",
+              mod.descriptor().name(),
+              mod.location().map(URI::toString).orElse("<unknown location>"));
         });
 
-        var compilerArgs = new ArrayList<>(compileJava.getOptions().getCompilerArgs());
-        compilerArgs.add("--module-path");
-        compilerArgs.add(compileJava.getClasspath().getAsPath());
+        var moduleNames =
+            modules.stream().map(mod -> mod.descriptor().name()).collect(Collectors.joining(","));
 
-        compilerArgs.add("--add-modules");
-        compilerArgs.add(moduleNames);
-
-        compileJava.getOptions().setCompilerArgs(compilerArgs);
+        compileJava.getOptions().getCompilerArgs().addAll(List.of(
+            "--module-path",
+            compileJava.getClasspath().getAsPath(),
+            "--add-modules",
+            moduleNames
+        ));
       });
     });
   }

--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIPlugin.java
@@ -40,6 +40,7 @@ public class WPIPlugin implements Plugin<Project> {
 
         project.getPluginManager().apply(WPIToolsPlugin.class);
         project.getPluginManager().apply(WPIDependenciesPlugin.class);
+        project.getPluginManager().apply(WPIModulesPlugin.class);
 
         project.getTasks().register("wpiVersions", task -> {
             task.setGroup("GradleRIO");


### PR DESCRIPTION
Allows user programs to use `import module` statements without needing to write `module-info.java` files (and keep them up to date as they add vendor libraries)

See https://github.com/wpilibsuite/allwpilib/pull/7424

Note that CI checks will fail until EJML is modularized. It currently splits packages across multiple JARs, which is disallowed by the Java module system.