### PR TITLE
Update frcYear to 2026beta

### DIFF
--- a/src/main/java/edu/wpi/first/gradlerio/wpi/WPIExtension.java
+++ b/src/main/java/edu/wpi/first/gradlerio/wpi/WPIExtension.java
@@ -63,7 +63,7 @@ public class WPIExtension {
         platforms = new NativePlatforms();
 
         frcYear = factory.property(String.class);
-        frcYear.convention("2025");
+        frcYear.convention("2026beta");
 
         frcHome = factory.directoryProperty().fileProvider(project.provider(WPIExtension::computeHomeRoot))
                 .dir(frcYear);

--- a/testing/asm/settings.gradle
+++ b/testing/asm/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        String frcYear = '2025'
+        String frcYear = '2026beta'
         File frcHome
         if (OperatingSystem.current().isWindows()) {
             String publicFolder = System.getenv('PUBLIC')

--- a/testing/java/settings.gradle
+++ b/testing/java/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        String frcYear = '2025'
+        String frcYear = '2026beta'
         File frcHome
         if (OperatingSystem.current().isWindows()) {
             String publicFolder = System.getenv('PUBLIC')

--- a/testing/jni/settings.gradle
+++ b/testing/jni/settings.gradle
@@ -4,7 +4,7 @@ pluginManagement {
     repositories {
         mavenLocal()
         gradlePluginPortal()
-        String frcYear = '2025'
+        String frcYear = '2026beta'
         File frcHome
         if (OperatingSystem.current().isWindows()) {
             String publicFolder = System.getenv('PUBLIC')


### PR DESCRIPTION
In past betas we used just the year which let beta vendordeps be use with releases. This will make beta vendordeps only loadable with on beta projects