### PR TITLE
Add poison pill for simulateJava task

### DIFF
--- a/src/main/java/org/wpilib/gradlerio/wpi/java/WPIJavaExtension.java
+++ b/src/main/java/org/wpilib/gradlerio/wpi/java/WPIJavaExtension.java
@@ -284,7 +284,13 @@ public class WPIJavaExtension {
                 });
 
         project.getTasks().register("simulateJava", t -> {
-            throw new GradleException("The simulateJava task has been removed. Use run instead.");
+            t.doLast(new Action<Task>() {
+                @Override
+                public void execute(Task arg0) {
+                    throw new GradleException("The simulateJava task has been removed. Use run instead.");
+                }
+            });
+
         });
     }
 }

--- a/src/main/java/org/wpilib/gradlerio/wpi/java/WPIJavaExtension.java
+++ b/src/main/java/org/wpilib/gradlerio/wpi/java/WPIJavaExtension.java
@@ -282,5 +282,9 @@ public class WPIJavaExtension {
                     t.getSimulationFile().set(project.getLayout().getBuildDirectory().file("sim/java.json"));
                     t.setDependencies(typedExtractNativeArtifacts, runSimWithDebugJni);
                 });
+
+        project.getTasks().register("simulateJava", t -> {
+            throw new GradleException("The simulateJava task has been removed. Use run instead.");
+        });
     }
 }


### PR DESCRIPTION
This way gradle doesn't try to run simulateExternalJava.

Closes #863 